### PR TITLE
Fix CORS headers to allow frontend calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,8 @@ from message_history import load_messages_from_file, save_messages_to_file
 from chapter_log import append_chapter_entry
 
 app = Flask(__name__, static_folder='static')
-CORS(app)
+# Explicitly allow cross-origin requests from any domain to fix frontend CORS errors
+CORS(app, resources={r"/*": {"origins": "*"}})
 
 @app.route('/')
 def root():


### PR DESCRIPTION
## Summary
- explicitly allow cross-origin requests for all routes

## Testing
- `python -m py_compile app.py message_history.py chapter_log.py token_counter.py`


------
https://chatgpt.com/codex/tasks/task_e_684a96c5434c8329986569109ddc3edb