### PR TITLE
Switch JS to local API endpoints

### DIFF
--- a/static/call-of-cthulhu/index.html
+++ b/static/call-of-cthulhu/index.html
@@ -99,7 +99,7 @@
         input.value = "";
 
         try {
-          const response = await fetch("https://mydemerzel.onrender.com/chat", {
+          const response = await fetch("/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ message: userMessage })

--- a/static/master-template/index.html
+++ b/static/master-template/index.html
@@ -99,7 +99,7 @@
         input.value = "";
 
         try {
-          const response = await fetch("https://mydemerzel.onrender.com/chat", {
+          const response = await fetch("/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ message: userMessage })

--- a/static/the-one-ring/Backup Files/script - Copy.js
+++ b/static/the-one-ring/Backup Files/script - Copy.js
@@ -23,7 +23,7 @@ async function saveCharacterSheet(name) {
       formData[key] = val;
     }
 
-    const res = await fetch("https://mydemerzel.onrender.com/save-character", {
+    const res = await fetch("/save-character", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, fieldData: formData })
@@ -40,7 +40,7 @@ async function saveCharacterSheet(name) {
 async function loadCharacterSheet(name) {
   const safeName = name.toLowerCase().trim().replace(/\s+/g, "_");
   try {
-    const response = await fetch(`https://mydemerzel.onrender.com/load-character/${safeName}`);
+    const response = await fetch(`/load-character/${safeName}`);
     if (!response.ok) {
       appendMessage("System", "Character not found.", "assistant");
       return;
@@ -113,7 +113,7 @@ Available commands:
 
     if (!systemResponded) {
       try {
-        const response = await fetch("https://mydemerzel.onrender.com/chat", {
+        const response = await fetch("/chat", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ message: userMessage })

--- a/static/the-one-ring/script.js
+++ b/static/the-one-ring/script.js
@@ -63,7 +63,7 @@ async function saveCharacterSheet(name) {
 
     const fields = await extractPdfFields();
 
-    const res = await fetch("https://mydemerzel.onrender.com/save-character", {
+    const res = await fetch("/save-character", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -85,7 +85,7 @@ async function loadCharacterSheet(name) {
   const safeName = normalizeName(name);
   try {
     // Use the direct endpoint; PDF.js can fetch directly.
-    const pdfUrl = `https://mydemerzel.onrender.com/load-character/${safeName}`;
+    const pdfUrl = `/load-character/${safeName}`;
     pdfFrame.src = `${PDF_VIEWER_PATH}?file=${encodeURIComponent(pdfUrl)}`;
     appendMessage("System", `Character sheet '${name}' loaded successfully.`, "assistant");
     // Optionally, clear currentTemplatePdfPath here because we loaded a saved character
@@ -158,7 +158,7 @@ Available commands:
 
     if (!systemResponded) {
       try {
-        const response = await fetch("https://mydemerzel.onrender.com/chat", {
+        const response = await fetch("/chat", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ message: userMessage })


### PR DESCRIPTION
## Summary
- update The One Ring character sheet script to use relative API URLs
- adjust backup script the same way
- fix chat fetch paths in Call of Cthulhu and Master Template pages

## Testing
- `pip install -r requirements.txt`
- `nohup python app.py > /tmp/flask.log 2>&1 &`
- `curl -I http://127.0.0.1:5000/the-one-ring`

------
https://chatgpt.com/codex/tasks/task_e_684aa458447483299bbbc09d80c098c1