### PR TITLE
Fix viewer path

### DIFF
--- a/static/the-one-ring/script.js
+++ b/static/the-one-ring/script.js
@@ -2,8 +2,10 @@ const messages = document.getElementById("messages");
 const input = document.getElementById("userInput");
 const pdfFrame = document.getElementById("pdfFrame");
 
-// Path to the PDF.js viewer relative to this script/index.html file
-const PDF_VIEWER_PATH = "../../pdfjs/web/viewer.html";
+// Path to the PDF.js viewer. Using an absolute path ensures the viewer and
+// referenced PDF files are correctly resolved regardless of the current page
+// location.
+const PDF_VIEWER_PATH = "/static/pdfjs/web/viewer.html";
 
 // Store currently used template (race PDF), to pass to backend on save
 let currentTemplatePdfPath = null;


### PR DESCRIPTION
## Summary
- fix path to the PDF.js viewer so PDFs load correctly

## Testing
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0d3f7b08329911d584e2d57846c