### PR TITLE
Fix annotation field extraction for new pdf.js

### DIFF
--- a/static/the-one-ring/script.js
+++ b/static/the-one-ring/script.js
@@ -37,10 +37,13 @@ async function extractPdfFields() {
       const viewer = pdfFrame.contentWindow.PDFViewerApplication;
       const fields = {};
 
-      const annotations = viewer._annotationStorage._storage;
-      for (const [key, value] of Object.entries(annotations)) {
-        if (value && value.value !== undefined) {
-          fields[key] = value.value;
+      const annotationStorage = viewer?.pdfDocument?.annotationStorage;
+      const map = annotationStorage?.serializable?.map;
+      if (map) {
+        for (const [key, value] of map.entries()) {
+          if (value && value.value !== undefined) {
+            fields[key] = value.value;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- iterate over `viewer.pdfDocument.annotationStorage.serializable.map` when reading PDF form data
- handle cases where `annotationStorage` or its `serializable` map is missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ab56deed483299a5a5fcc997af7aa