### PR TITLE
Improve fetch error handling

### DIFF
--- a/static/call-of-cthulhu/index.html
+++ b/static/call-of-cthulhu/index.html
@@ -105,6 +105,12 @@
             body: JSON.stringify({ message: userMessage })
           });
 
+          if (!response.ok) {
+            const text = await response.text();
+            appendMessage("Error", `Server error ${response.status}: ${text}` , "assistant");
+            return;
+          }
+
           const data = await response.json();
           appendMessage("Demerzel", data.response, "assistant");
         } catch (error) {

--- a/static/master-template/index.html
+++ b/static/master-template/index.html
@@ -105,6 +105,12 @@
             body: JSON.stringify({ message: userMessage })
           });
 
+          if (!response.ok) {
+            const text = await response.text();
+            appendMessage("Error", `Server error ${response.status}: ${text}` , "assistant");
+            return;
+          }
+
           const data = await response.json();
           appendMessage("Demerzel", data.response, "assistant");
         } catch (error) {

--- a/static/the-one-ring/Backup Files/script - Copy.js
+++ b/static/the-one-ring/Backup Files/script - Copy.js
@@ -29,6 +29,12 @@ async function saveCharacterSheet(name) {
       body: JSON.stringify({ name, fieldData: formData })
     });
 
+    if (!res.ok) {
+      const text = await res.text();
+      appendMessage("System", `Error ${res.status}: ${text}` , "assistant");
+      return;
+    }
+
     const result = await res.json();
     appendMessage("System", result.message || result.error || "Unknown response.", "assistant");
   } catch (err) {
@@ -118,6 +124,12 @@ Available commands:
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ message: userMessage })
         });
+
+        if (!response.ok) {
+          const text = await response.text();
+          appendMessage("Error", `Server error ${response.status}: ${text}` , "assistant");
+          return;
+        }
 
         const data = await response.json();
         appendMessage("Demerzel", data.response, "assistant");

--- a/static/the-one-ring/script.js
+++ b/static/the-one-ring/script.js
@@ -78,6 +78,12 @@ async function saveCharacterSheet(name) {
       })
     });
 
+    if (!res.ok) {
+      const text = await res.text();
+      appendMessage("System", `Error ${res.status}: ${text}`, "assistant");
+      return;
+    }
+
     const result = await res.json();
     appendMessage("System", result.message || result.error || "Unknown response.", "assistant");
   } catch (err) {
@@ -168,6 +174,12 @@ Available commands:
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ message: userMessage })
         });
+
+        if (!response.ok) {
+          const text = await response.text();
+          appendMessage("Error", `Server error ${response.status}: ${text}` , "assistant");
+          return;
+        }
 
         const data = await response.json();
         appendMessage("Demerzel", data.response, "assistant");


### PR DESCRIPTION
## Summary
- verify `res.ok` before parsing `/save-character` response in script.js
- handle server errors for `/chat` in all demo pages
- update backup JS copy with same error checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac13870008329a51b8832d8ebe870