### PR TITLE
Add pdf-lib script and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Demerzel Project
+
+This repository contains a small Flask application with a frontend that allows filling out RPG character sheets. Character data is written to PDFs by a Node.js script executed from the `/save-character` endpoint.
+
+## Requirements
+
+* Python 3 with the packages from `requirements.txt` (install with `pip install -r requirements.txt`)
+* Node.js (v18 or later is recommended)
+* The Node package `pdf-lib` used by `fill_pdf.js`
+
+Install the Node dependency by running:
+
+```bash
+npm install pdf-lib
+```
+
+## Running
+
+1. Ensure the `node` command is available and the `pdf-lib` package is installed as shown above.
+2. Install the Python dependencies: `pip install -r requirements.txt`.
+3. Start the Flask app:
+
+```bash
+python app.py
+```
+
+The `/save-character` endpoint expects a JSON payload with `name`, `template` and `fieldData`. The Node script `fill_pdf.js` fills the specified PDF template with the provided form data and writes the resulting PDF to `/mnt/data/<name>.pdf`.

--- a/fill_pdf.js
+++ b/fill_pdf.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { PDFDocument } = require('pdf-lib');
+
+async function main() {
+  const [template, name] = process.argv.slice(2);
+  if (!template || !name) {
+    console.error('Usage: node fill_pdf.js <template> <name>');
+    process.exit(1);
+  }
+
+  const templatePath = path.join(__dirname, 'static', 'pdfjs', 'web', template);
+  const dataPath = path.join('/mnt/data', `${name}_fields.json`);
+  const outputPath = path.join('/mnt/data', `${name}.pdf`);
+
+  try {
+    const fieldData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const pdfBytes = fs.readFileSync(templatePath);
+    const pdfDoc = await PDFDocument.load(pdfBytes);
+    const form = pdfDoc.getForm();
+
+    for (const [key, value] of Object.entries(fieldData)) {
+      let field;
+      try {
+        field = form.getField(key);
+      } catch (err) {
+        continue; // Skip missing fields
+      }
+      if (field.setText) {
+        field.setText(String(value));
+      } else if (field.select) {
+        field.select(String(value));
+      } else if (field.check) {
+        if (value === true || value === 'Yes' || value === 'On') {
+          field.check();
+        } else {
+          field.uncheck();
+        }
+      }
+    }
+
+    form.flatten();
+    const outBytes = await pdfDoc.save();
+    fs.writeFileSync(outputPath, outBytes);
+  } catch (err) {
+    console.error(err.message || err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add fill_pdf.js Node script for PDF form generation
- document Node.js requirement and install steps
- improve error handling in `/save-character` route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac21029e88329b0b5c6076950e08d