### PR TITLE
Add pdf-lib startup check and README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Install the Node dependency by running:
 npm install pdf-lib
 ```
 
+The `/save-character` feature relies on this package. Be sure to run the above
+command before trying to save a character or the PDF generation will fail.
+
 ## Running
 
 1. Ensure the `node` command is available and the `pdf-lib` package is installed as shown above.

--- a/app.py
+++ b/app.py
@@ -16,6 +16,23 @@ app = Flask(__name__, static_folder='static')
 # Explicitly allow cross-origin requests from any domain to fix frontend CORS errors
 CORS(app, resources={r"/*": {"origins": "*"}})
 
+# Startup check for the pdf-lib dependency used by fill_pdf.js
+def check_pdf_lib():
+    """Log a helpful message if the pdf-lib npm package is missing."""
+    try:
+        result = subprocess.run(["node", "-e", "require('pdf-lib')"], capture_output=True, text=True)
+        if result.returncode != 0:
+            app.logger.error(
+                "The 'pdf-lib' npm package is required for the save character feature. "
+                "Run 'npm install pdf-lib' as described in README.md."
+            )
+    except FileNotFoundError:
+        app.logger.error(
+            "Node.js is required to use the save character feature but was not found."
+        )
+
+check_pdf_lib()
+
 @app.route('/')
 def root():
     return app.send_static_file('index.html')


### PR DESCRIPTION
## Summary
- document that npm install pdf-lib is required before using `/save-character`
- check at startup that pdf-lib can be required and log helpful message if missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac6e6aadc8329930958f47b2836a7