### PR TITLE
Enforce PDF template whitelist and add tests

### DIFF
--- a/fill_pdf.js
+++ b/fill_pdf.js
@@ -9,7 +9,9 @@ async function main() {
     process.exit(1);
   }
 
-  const templatePath = path.join(__dirname, 'static', 'pdfjs', 'web', template);
+  // The template name is validated by the Flask application, so we simply
+  // resolve it within the bundled pdfs directory.
+  const templatePath = path.join(__dirname, 'static', 'pdfjs', 'web', 'pdfs', template);
   const dataPath = path.join('/mnt/data', `${name}_fields.json`);
   const outputPath = path.join('/mnt/data', `${name}.pdf`);
 

--- a/test_template_validation.py
+++ b/test_template_validation.py
@@ -1,0 +1,34 @@
+import json
+from unittest.mock import patch, MagicMock
+from app import app, ALLOWED_TEMPLATES
+
+
+def _post_save(client, template):
+    payload = {
+        "name": "Test",
+        "template": template,
+        "fieldData": {"a": 1}
+    }
+    return client.post('/save-character', data=json.dumps(payload), content_type='application/json')
+
+
+def test_save_character_valid_template():
+    with app.test_client() as client:
+        with patch('subprocess.run') as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            resp = _post_save(client, next(iter(ALLOWED_TEMPLATES)))
+            assert resp.status_code == 200
+
+
+def test_save_character_template_not_allowed():
+    with app.test_client() as client:
+        resp = _post_save(client, 'pdfs/invalid.pdf')
+        assert resp.status_code == 400
+        assert resp.get_json()['error'] == 'Template not allowed'
+
+
+def test_save_character_template_traversal():
+    with app.test_client() as client:
+        resp = _post_save(client, '../secret.pdf')
+        assert resp.status_code == 400
+        assert resp.get_json()['error'] == 'Invalid template path'


### PR DESCRIPTION
## Summary
- restrict `/save-character` template to a whitelist of allowed PDFs
- validate template paths before generating PDFs
- update `fill_pdf.js` to assume sanitized input
- test valid and invalid template names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aca1d2ee0832997616601b33e4321