### PR TITLE
Fix PDF save path error

### DIFF
--- a/fill_pdf.js
+++ b/fill_pdf.js
@@ -11,7 +11,11 @@ async function main() {
 
   // The template name is validated by the Flask application, so we simply
   // resolve it within the bundled pdfs directory.
-  const templatePath = path.join(__dirname, 'static', 'pdfjs', 'web', 'pdfs', template);
+  // Allow template to be passed either as "dwarf.pdf" or "pdfs/dwarf.pdf".
+  const templateName = template.startsWith('pdfs' + path.sep)
+    ? template.slice(5)
+    : template;
+  const templatePath = path.join(__dirname, 'static', 'pdfjs', 'web', 'pdfs', templateName);
   const dataPath = path.join('/mnt/data', `${name}_fields.json`);
   const outputPath = path.join('/mnt/data', `${name}.pdf`);
 

--- a/test_fill_pdf_path.py
+++ b/test_fill_pdf_path.py
@@ -1,0 +1,15 @@
+import json
+import os
+import subprocess
+
+
+def test_fill_pdf_accepts_prefixed_template():
+    json_path = '/mnt/data/tmp_fields.json'
+    pdf_path = '/mnt/data/tmp.pdf'
+    with open(json_path, 'w') as f:
+        json.dump({'Name': 'Bob'}, f)
+    result = subprocess.run(['node', 'fill_pdf.js', 'pdfs/dwarf.pdf', 'tmp'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert os.path.exists(pdf_path)
+    os.remove(json_path)
+    os.remove(pdf_path)


### PR DESCRIPTION
## Summary
- resolve PDF template path when `pdfs/` prefix is provided
- add regression test for Node script path handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acea1a7608329916e1138189c86ab