### PR TITLE
Fix /mnt/data path for PDF test

### DIFF
--- a/test_fill_pdf_path.py
+++ b/test_fill_pdf_path.py
@@ -2,6 +2,8 @@ import json
 import os
 import subprocess
 
+os.makedirs('/mnt/data', exist_ok=True)
+
 
 def test_fill_pdf_accepts_prefixed_template():
     json_path = '/mnt/data/tmp_fields.json'


### PR DESCRIPTION
## Summary
- create `/mnt/data` directory when running `test_fill_pdf_path.py`

## Testing
- `npm install pdf-lib`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad2a8bf8883299c3bd598e12600dd