### PR TITLE
Update setup script to install pdf-lib

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,3 +1,9 @@
 pip install openai
 pip install python-dotenv
 pip install PyPDF2
+
+# Install packages listed in requirements.txt for consistency
+pip install -r requirements.txt
+
+# Install Node dependency used by fill_pdf.js
+npm install pdf-lib


### PR DESCRIPTION
## Summary
- ensure `pdf-lib` is installed during setup
- install Python packages from `requirements.txt`

## Testing
- `npm install pdf-lib`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad2a1b7f483299b4b1598087d37b1