### PR TITLE
Fix PDF output directory creation

### DIFF
--- a/fill_pdf.js
+++ b/fill_pdf.js
@@ -47,6 +47,7 @@ async function main() {
 
     form.flatten();
     const outBytes = await pdfDoc.save();
+    fs.mkdirSync('/mnt/data', { recursive: true });
     fs.writeFileSync(outputPath, outBytes);
   } catch (err) {
     console.error(err.message || err);

--- a/test_fill_pdf_path.py
+++ b/test_fill_pdf_path.py
@@ -2,10 +2,9 @@ import json
 import os
 import subprocess
 
-os.makedirs('/mnt/data', exist_ok=True)
-
 
 def test_fill_pdf_accepts_prefixed_template():
+    os.makedirs('/mnt/data', exist_ok=True)
     json_path = '/mnt/data/tmp_fields.json'
     pdf_path = '/mnt/data/tmp.pdf'
     with open(json_path, 'w') as f:


### PR DESCRIPTION
## Summary
- ensure `/mnt/data` exists when writing PDFs
- make test create `/mnt/data` to work in a clean environment

## Testing
- `pip install -q -r requirements.txt`
- `npm install pdf-lib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad6ccc600832987df6b56a396112c