### PR TITLE
Remove binary diff and tidy code

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,35 +1,35 @@
 from flask_cors import CORS, cross_origin
-from flask import Flask, request, jsonify
+from flask import Flask, jsonify, request
 import datetime
-import re
-import os
-import json
 from dotenv import load_dotenv
 from openai import OpenAI
 from token_counter import count_tokens
 from message_history import load_messages_from_file, save_messages_to_file
-from chapter_log import append_chapter_entry
 
-app = Flask(__name__, static_folder='static')
+app = Flask(__name__, static_folder="static")
 # Explicitly allow cross-origin requests from any domain to fix frontend CORS errors
 CORS(app, resources={r"/*": {"origins": "*"}})
 
 
-@app.route('/')
+@app.route("/")
 def root():
-    return app.send_static_file('index.html')
+    return app.send_static_file("index.html")
 
-@app.route('/the-one-ring')
+
+@app.route("/the-one-ring")
 def the_one_ring():
-    return app.send_static_file('the-one-ring/index.html')
+    return app.send_static_file("the-one-ring/index.html")
 
-@app.route('/call-of-cthulhu')
+
+@app.route("/call-of-cthulhu")
 def call_of_cthulhu():
-    return app.send_static_file('call-of-cthulhu/index.html')
+    return app.send_static_file("call-of-cthulhu/index.html")
 
-@app.route('/master-template')
+
+@app.route("/master-template")
 def master_template():
-    return app.send_static_file('master-template/index.html')
+    return app.send_static_file("master-template/index.html")
+
 
 # Load environment variables and OpenAI client
 load_dotenv()
@@ -45,13 +45,21 @@ messages = load_messages_from_file()
 
 def summarize_messages(messages):
     to_summarize = [m for m in messages if m["role"] in ["user", "assistant"]][-12:]
-    summary_prompt = [{"role": "system", "content": "Summarize the following RPG conversation so far in a concise but detailed paragraph. Focus on world events, decisions made, and NPC interactions. Be specific."}] + to_summarize
-    response = client.chat.completions.create(model="gpt-3.5-turbo", messages=summary_prompt)
+    summary_prompt = [
+        {
+            "role": "system",
+            "content": "Summarize the following RPG conversation so far in a concise but detailed paragraph. Focus on world events, decisions made, and NPC interactions. Be specific.",
+        }
+    ] + to_summarize
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo", messages=summary_prompt
+    )
     summary = response.choices[0].message.content.strip()
     return [{"role": "system", "content": f"SUMMARY OF EARLIER CHAT: {summary}"}]
 
+
 @app.route("/chat", methods=["POST"])
-@cross_origin()       # explicitly allow all origins
+@cross_origin()  # explicitly allow all origins
 def chat():
     global messages
     data = request.get_json(silent=True)
@@ -67,7 +75,9 @@ def chat():
 
     if user_input == "?":
         help_text = "**Available Commands:**\n- `?` – Show this help menu"
-        messages.append({"role": "assistant", "content": help_text, "timestamp": timestamp})
+        messages.append(
+            {"role": "assistant", "content": help_text, "timestamp": timestamp}
+        )
         save_messages_to_file(messages)
         return jsonify({"response": help_text})
 
@@ -81,15 +91,14 @@ def chat():
         messages = [summary_message] + recent
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=full_messages,
-        max_tokens=100
+        model="gpt-3.5-turbo", messages=full_messages, max_tokens=100
     )
     trimmed = response.choices[0].message.content.strip()
     messages.append({"role": "assistant", "content": trimmed, "timestamp": timestamp})
     save_messages_to_file(messages)
 
     return jsonify({"response": trimmed})
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/chapter_log.py
+++ b/chapter_log.py
@@ -4,22 +4,21 @@ from datetime import datetime
 
 CHAPTER_LOG_FILE = "chapter_log.json"
 
+
 def load_chapter_log():
     if os.path.exists(CHAPTER_LOG_FILE):
         with open(CHAPTER_LOG_FILE, "r", encoding="utf-8") as f:
             return json.load(f)
     return []
 
+
 def save_chapter_log(log):
     with open(CHAPTER_LOG_FILE, "w", encoding="utf-8") as f:
         json.dump(log, f, ensure_ascii=False, indent=2)
 
+
 def append_chapter_entry(title, description):
     log = load_chapter_log()
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    log.append({
-        "timestamp": timestamp,
-        "title": title,
-        "description": description
-    })
+    log.append({"timestamp": timestamp, "title": title, "description": description})
     save_chapter_log(log)

--- a/message_history.py
+++ b/message_history.py
@@ -2,6 +2,7 @@ import os
 import json
 import datetime
 
+
 def save_messages_to_file(messages, filename="chat_history.json"):
     # Inject timestamp into any message that doesn't already have one
     for message in messages:

--- a/test_app_invalid_json.py
+++ b/test_app_invalid_json.py
@@ -1,11 +1,10 @@
-import json
 from app import app
 
 
 def test_chat_invalid_json():
     with app.test_client() as client:
-        response = client.post('/chat', data='bad json', content_type='application/json')
+        response = client.post(
+            "/chat", data="bad json", content_type="application/json"
+        )
         assert response.status_code == 400
-        assert response.get_json() == {'error': 'Invalid JSON payload'}
-
-
+        assert response.get_json() == {"error": "Invalid JSON payload"}

--- a/test_full_app.py
+++ b/test_full_app.py
@@ -11,13 +11,13 @@ def fake_openai_response(content="Hello from OpenAI"):
 
 def test_root_page():
     with app.test_client() as client:
-        resp = client.get('/')
+        resp = client.get("/")
         assert resp.status_code == 200
         assert b"Demerzel" in resp.data
 
 
 def test_static_pages():
-    paths = ['/the-one-ring', '/call-of-cthulhu', '/master-template']
+    paths = ["/the-one-ring", "/call-of-cthulhu", "/master-template"]
     with app.test_client() as client:
         for path in paths:
             resp = client.get(path)
@@ -26,19 +26,23 @@ def test_static_pages():
 
 def test_chat_success():
     app.messages = []
-    with patch('app.save_messages_to_file'), \
-         patch('app.summarize_messages', return_value=[{'role':'system','content':'summary'}]), \
-         patch('app.client.chat.completions.create', return_value=fake_openai_response("test reply")) as mock_create:
+    with patch("app.save_messages_to_file"), patch(
+        "app.summarize_messages",
+        return_value=[{"role": "system", "content": "summary"}],
+    ), patch(
+        "app.client.chat.completions.create",
+        return_value=fake_openai_response("test reply"),
+    ) as mock_create:
         with app.test_client() as client:
-            resp = client.post('/chat', json={'message': 'hello'})
+            resp = client.post("/chat", json={"message": "hello"})
             assert resp.status_code == 200
             data = resp.get_json()
-            assert data['response'] == 'test reply'
+            assert data["response"] == "test reply"
             mock_create.assert_called_once()
 
 
 def test_chat_empty_input():
     with app.test_client() as client:
-        resp = client.post('/chat', json={'message': '   '})
+        resp = client.post("/chat", json={"message": "   "})
         assert resp.status_code == 400
-        assert resp.get_json() == {'error': 'Empty input'}
+        assert resp.get_json() == {"error": "Empty input"}


### PR DESCRIPTION
## Summary
- revert `.gitignore` to its original encoding so the PR contains no binary diffs
- streamline imports and quoting in the Flask app
- tidy chapter log helpers and the command line chat client
- simplify unit tests formatting

## Testing
- `bash .codex/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb4eb63d08329b7d1d6b8b4e8676e