### PR TITLE
Convert Figma rectangles to text inputs

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2024,3 +2024,14 @@ body {
   left: 0px;
   overflow: hidden;
 }
+.invisible-input {
+  background: none;
+  border: none;
+  outline: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  color: #f0f0f0;
+  font-size: inherit;
+  font-family: inherit;
+}

--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -89,62 +89,62 @@
   <!-- LEFT PANEL: Figma Layout -->
   <div class="left-panel">
     <div class="v3_19">
-      <div class="v5_6"></div><div class="v9_90"></div><div class="v9_92"></div><div class="v9_88"></div>
-      <div class="v9_86"></div><div class="v9_84"></div><div class="v9_82"></div><div class="v9_80"></div>
-      <div class="v9_78"></div><div class="v9_76"></div><div class="v9_74"></div><div class="v9_72"></div>
-      <div class="v9_70"></div><div class="v9_68"></div><div class="v9_66"></div><div class="v9_64"></div>
-      <div class="v9_62"></div><div class="v9_58"></div><div class="v9_59"></div><div class="v9_60"></div>
-      <div class="v9_54"></div><div class="v9_55"></div><div class="v9_56"></div><div class="v9_52"></div>
-      <div class="v9_50"></div><div class="v9_48"></div><div class="v9_18"></div><div class="v7_220"></div>
-      <div class="v7_221"></div><div class="v7_222"></div><div class="v7_223"></div><div class="v7_224"></div>
-      <div class="v7_225"></div><div class="v7_206"></div><div class="v7_207"></div><div class="v7_208"></div>
-      <div class="v7_209"></div><div class="v7_210"></div><div class="v7_211"></div><div class="v7_199"></div>
-      <div class="v7_200"></div><div class="v7_201"></div><div class="v7_202"></div><div class="v7_203"></div>
-      <div class="v7_204"></div><div class="v7_192"></div><div class="v7_193"></div><div class="v7_194"></div>
-      <div class="v7_195"></div><div class="v7_196"></div><div class="v7_197"></div><div class="v7_185"></div>
-      <div class="v7_186"></div><div class="v7_187"></div><div class="v7_188"></div><div class="v7_189"></div>
-      <div class="v7_190"></div><div class="v7_171"></div><div class="v7_172"></div><div class="v7_173"></div>
-      <div class="v7_174"></div><div class="v7_175"></div><div class="v7_176"></div><div class="v7_164"></div>
-      <div class="v7_165"></div><div class="v7_166"></div><div class="v7_167"></div><div class="v7_168"></div>
-      <div class="v7_169"></div><div class="v7_157"></div><div class="v7_158"></div><div class="v7_159"></div>
-      <div class="v7_160"></div><div class="v7_161"></div><div class="v7_162"></div><div class="v7_150"></div>
-      <div class="v7_151"></div><div class="v7_152"></div><div class="v7_153"></div><div class="v7_154"></div>
-      <div class="v7_155"></div><div class="v7_143"></div><div class="v7_144"></div><div class="v7_145"></div>
-      <div class="v7_146"></div><div class="v7_147"></div><div class="v7_148"></div><div class="v6_54"></div>
-      <div class="v6_52"></div><div class="v6_39"></div><div class="v6_27"></div><div class="v6_28"></div>
-      <div class="v6_29"></div><div class="v5_3"></div><div class="v6_8"></div><div class="v6_9"></div>
-      <div class="v6_14"></div><div class="v6_37"></div><div class="v9_94"></div><div class="v6_42"></div>
-      <div class="v6_56"></div><div class="v6_68"></div><div class="v6_70"></div><div class="v6_72"></div>
-      <div class="v6_74"></div><div class="v6_76"></div><div class="v6_78"></div><div class="v7_122"></div>
-      <div class="v7_123"></div><div class="v7_124"></div><div class="v7_125"></div><div class="v7_126"></div>
-      <div class="v7_127"></div><div class="v6_80"></div><div class="v6_81"></div><div class="v6_82"></div>
-      <div class="v6_83"></div><div class="v6_84"></div><div class="v6_85"></div><div class="v7_87"></div>
-      <div class="v7_88"></div><div class="v7_89"></div><div class="v7_90"></div><div class="v7_91"></div>
-      <div class="v7_92"></div><div class="v7_94"></div><div class="v7_95"></div><div class="v7_96"></div>
-      <div class="v7_97"></div><div class="v7_98"></div><div class="v7_99"></div><div class="v7_101"></div>
-      <div class="v7_102"></div><div class="v7_103"></div><div class="v7_104"></div><div class="v7_105"></div>
-      <div class="v7_106"></div><div class="v7_213"></div><div class="v7_214"></div><div class="v7_215"></div>
-      <div class="v7_216"></div><div class="v7_217"></div><div class="v7_218"></div><div class="v7_108"></div>
-      <div class="v7_109"></div><div class="v7_110"></div><div class="v7_111"></div><div class="v7_112"></div>
-      <div class="v7_113"></div><div class="v7_227"></div><div class="v7_228"></div><div class="v7_229"></div>
-      <div class="v7_230"></div><div class="v7_231"></div><div class="v7_232"></div><div class="v7_234"></div>
-      <div class="v7_235"></div><div class="v7_236"></div><div class="v7_237"></div><div class="v7_238"></div>
-      <div class="v7_239"></div><div class="v9_2"></div><div class="v9_3"></div><div class="v9_4"></div>
-      <div class="v9_5"></div><div class="v9_6"></div><div class="v9_7"></div><div class="v9_9"></div>
-      <div class="v9_10"></div><div class="v9_11"></div><div class="v9_12"></div><div class="v9_13"></div>
-      <div class="v9_14"></div><div class="v9_16"></div><div class="v6_58"></div><div class="v6_60"></div>
-      <div class="v6_62"></div><div class="v6_64"></div><div class="v6_66"></div><div class="v7_115"></div>
-      <div class="v7_116"></div><div class="v7_117"></div><div class="v7_118"></div><div class="v7_119"></div>
-      <div class="v7_120"></div><div class="v7_178"></div><div class="v7_179"></div><div class="v7_180"></div>
-      <div class="v7_181"></div><div class="v7_182"></div><div class="v7_183"></div><div class="v6_44"></div>
-      <div class="v6_48"></div><div class="v6_46"></div><div class="v6_50"></div><div class="v6_33"></div>
-      <div class="v6_25"></div><div class="v6_10"></div><div class="v6_16"></div><div class="v6_18"></div>
-      <div class="v6_12"></div><div class="v9_20"></div><div class="v9_28"></div><div class="v9_22"></div>
-      <div class="v9_24"></div><div class="v9_26"></div><div class="v9_30"></div><div class="v9_31"></div>
-      <div class="v9_32"></div><div class="v9_33"></div><div class="v9_34"></div><div class="v9_36"></div>
-      <div class="v9_37"></div><div class="v9_38"></div><div class="v9_39"></div><div class="v9_40"></div>
-      <div class="v9_42"></div><div class="v9_43"></div><div class="v9_44"></div><div class="v9_45"></div>
-      <div class="v9_46"></div><div class="v12_109"></div>
+      <div class="v5_6"></div><input class="v9_90 invisible-input" type="text" /><input class="v9_92 invisible-input" type="text" /><input class="v9_88 invisible-input" type="text" />
+      <input class="v9_86 invisible-input" type="text" /><input class="v9_84 invisible-input" type="text" /><input class="v9_82 invisible-input" type="text" /><input class="v9_80 invisible-input" type="text" />
+      <input class="v9_78 invisible-input" type="text" /><input class="v9_76 invisible-input" type="text" /><input class="v9_74 invisible-input" type="text" /><input class="v9_72 invisible-input" type="text" />
+      <input class="v9_70 invisible-input" type="text" /><input class="v9_68 invisible-input" type="text" /><input class="v9_66 invisible-input" type="text" /><input class="v9_64 invisible-input" type="text" />
+      <input class="v9_62 invisible-input" type="text" /><input class="v9_58 invisible-input" type="text" /><input class="v9_59 invisible-input" type="text" /><input class="v9_60 invisible-input" type="text" />
+      <input class="v9_54 invisible-input" type="text" /><input class="v9_55 invisible-input" type="text" /><input class="v9_56 invisible-input" type="text" /><input class="v9_52 invisible-input" type="text" />
+      <input class="v9_50 invisible-input" type="text" /><input class="v9_48 invisible-input" type="text" /><input class="v9_18 invisible-input" type="text" /><input class="v7_220 invisible-input" type="text" />
+      <input class="v7_221 invisible-input" type="text" /><input class="v7_222 invisible-input" type="text" /><input class="v7_223 invisible-input" type="text" /><input class="v7_224 invisible-input" type="text" />
+      <input class="v7_225 invisible-input" type="text" /><input class="v7_206 invisible-input" type="text" /><input class="v7_207 invisible-input" type="text" /><input class="v7_208 invisible-input" type="text" />
+      <input class="v7_209 invisible-input" type="text" /><input class="v7_210 invisible-input" type="text" /><input class="v7_211 invisible-input" type="text" /><input class="v7_199 invisible-input" type="text" />
+      <input class="v7_200 invisible-input" type="text" /><input class="v7_201 invisible-input" type="text" /><input class="v7_202 invisible-input" type="text" /><input class="v7_203 invisible-input" type="text" />
+      <input class="v7_204 invisible-input" type="text" /><input class="v7_192 invisible-input" type="text" /><input class="v7_193 invisible-input" type="text" /><input class="v7_194 invisible-input" type="text" />
+      <input class="v7_195 invisible-input" type="text" /><input class="v7_196 invisible-input" type="text" /><input class="v7_197 invisible-input" type="text" /><input class="v7_185 invisible-input" type="text" />
+      <input class="v7_186 invisible-input" type="text" /><input class="v7_187 invisible-input" type="text" /><input class="v7_188 invisible-input" type="text" /><input class="v7_189 invisible-input" type="text" />
+      <input class="v7_190 invisible-input" type="text" /><input class="v7_171 invisible-input" type="text" /><input class="v7_172 invisible-input" type="text" /><input class="v7_173 invisible-input" type="text" />
+      <input class="v7_174 invisible-input" type="text" /><input class="v7_175 invisible-input" type="text" /><input class="v7_176 invisible-input" type="text" /><input class="v7_164 invisible-input" type="text" />
+      <input class="v7_165 invisible-input" type="text" /><input class="v7_166 invisible-input" type="text" /><input class="v7_167 invisible-input" type="text" /><input class="v7_168 invisible-input" type="text" />
+      <input class="v7_169 invisible-input" type="text" /><input class="v7_157 invisible-input" type="text" /><input class="v7_158 invisible-input" type="text" /><input class="v7_159 invisible-input" type="text" />
+      <input class="v7_160 invisible-input" type="text" /><input class="v7_161 invisible-input" type="text" /><input class="v7_162 invisible-input" type="text" /><input class="v7_150 invisible-input" type="text" />
+      <input class="v7_151 invisible-input" type="text" /><input class="v7_152 invisible-input" type="text" /><input class="v7_153 invisible-input" type="text" /><input class="v7_154 invisible-input" type="text" />
+      <input class="v7_155 invisible-input" type="text" /><input class="v7_143 invisible-input" type="text" /><input class="v7_144 invisible-input" type="text" /><input class="v7_145 invisible-input" type="text" />
+      <input class="v7_146 invisible-input" type="text" /><input class="v7_147 invisible-input" type="text" /><input class="v7_148 invisible-input" type="text" /><input class="v6_54 invisible-input" type="text" />
+      <input class="v6_52 invisible-input" type="text" /><input class="v6_39 invisible-input" type="text" /><input class="v6_27 invisible-input" type="text" /><input class="v6_28 invisible-input" type="text" />
+      <input class="v6_29 invisible-input" type="text" /><div class="v5_3"></div><input class="v6_8 invisible-input" type="text" /><input class="v6_9 invisible-input" type="text" />
+      <input class="v6_14 invisible-input" type="text" /><div class="v6_37"></div><input class="v9_94 invisible-input" type="text" /><input class="v6_42 invisible-input" type="text" />
+      <input class="v6_56 invisible-input" type="text" /><input class="v6_68 invisible-input" type="text" /><input class="v6_70 invisible-input" type="text" /><input class="v6_72 invisible-input" type="text" />
+      <input class="v6_74 invisible-input" type="text" /><input class="v6_76 invisible-input" type="text" /><input class="v6_78 invisible-input" type="text" /><input class="v7_122 invisible-input" type="text" />
+      <input class="v7_123 invisible-input" type="text" /><input class="v7_124 invisible-input" type="text" /><input class="v7_125 invisible-input" type="text" /><input class="v7_126 invisible-input" type="text" />
+      <input class="v7_127 invisible-input" type="text" /><input class="v6_80 invisible-input" type="text" /><input class="v6_81 invisible-input" type="text" /><input class="v6_82 invisible-input" type="text" />
+      <input class="v6_83 invisible-input" type="text" /><input class="v6_84 invisible-input" type="text" /><input class="v6_85 invisible-input" type="text" /><input class="v7_87 invisible-input" type="text" />
+      <input class="v7_88 invisible-input" type="text" /><input class="v7_89 invisible-input" type="text" /><input class="v7_90 invisible-input" type="text" /><input class="v7_91 invisible-input" type="text" />
+      <input class="v7_92 invisible-input" type="text" /><input class="v7_94 invisible-input" type="text" /><input class="v7_95 invisible-input" type="text" /><input class="v7_96 invisible-input" type="text" />
+      <input class="v7_97 invisible-input" type="text" /><input class="v7_98 invisible-input" type="text" /><input class="v7_99 invisible-input" type="text" /><input class="v7_101 invisible-input" type="text" />
+      <input class="v7_102 invisible-input" type="text" /><input class="v7_103 invisible-input" type="text" /><input class="v7_104 invisible-input" type="text" /><input class="v7_105 invisible-input" type="text" />
+      <input class="v7_106 invisible-input" type="text" /><input class="v7_213 invisible-input" type="text" /><input class="v7_214 invisible-input" type="text" /><input class="v7_215 invisible-input" type="text" />
+      <input class="v7_216 invisible-input" type="text" /><input class="v7_217 invisible-input" type="text" /><input class="v7_218 invisible-input" type="text" /><input class="v7_108 invisible-input" type="text" />
+      <input class="v7_109 invisible-input" type="text" /><input class="v7_110 invisible-input" type="text" /><input class="v7_111 invisible-input" type="text" /><input class="v7_112 invisible-input" type="text" />
+      <input class="v7_113 invisible-input" type="text" /><input class="v7_227 invisible-input" type="text" /><input class="v7_228 invisible-input" type="text" /><input class="v7_229 invisible-input" type="text" />
+      <input class="v7_230 invisible-input" type="text" /><input class="v7_231 invisible-input" type="text" /><input class="v7_232 invisible-input" type="text" /><input class="v7_234 invisible-input" type="text" />
+      <input class="v7_235 invisible-input" type="text" /><input class="v7_236 invisible-input" type="text" /><input class="v7_237 invisible-input" type="text" /><input class="v7_238 invisible-input" type="text" />
+      <input class="v7_239 invisible-input" type="text" /><input class="v9_2 invisible-input" type="text" /><input class="v9_3 invisible-input" type="text" /><input class="v9_4 invisible-input" type="text" />
+      <input class="v9_5 invisible-input" type="text" /><input class="v9_6 invisible-input" type="text" /><input class="v9_7 invisible-input" type="text" /><input class="v9_9 invisible-input" type="text" />
+      <input class="v9_10 invisible-input" type="text" /><input class="v9_11 invisible-input" type="text" /><input class="v9_12 invisible-input" type="text" /><input class="v9_13 invisible-input" type="text" />
+      <input class="v9_14 invisible-input" type="text" /><input class="v9_16 invisible-input" type="text" /><input class="v6_58 invisible-input" type="text" /><input class="v6_60 invisible-input" type="text" />
+      <input class="v6_62 invisible-input" type="text" /><input class="v6_64 invisible-input" type="text" /><input class="v6_66 invisible-input" type="text" /><input class="v7_115 invisible-input" type="text" />
+      <input class="v7_116 invisible-input" type="text" /><input class="v7_117 invisible-input" type="text" /><input class="v7_118 invisible-input" type="text" /><input class="v7_119 invisible-input" type="text" />
+      <input class="v7_120 invisible-input" type="text" /><input class="v7_178 invisible-input" type="text" /><input class="v7_179 invisible-input" type="text" /><input class="v7_180 invisible-input" type="text" />
+      <input class="v7_181 invisible-input" type="text" /><input class="v7_182 invisible-input" type="text" /><input class="v7_183 invisible-input" type="text" /><input class="v6_44 invisible-input" type="text" />
+      <input class="v6_48 invisible-input" type="text" /><input class="v6_46 invisible-input" type="text" /><input class="v6_50 invisible-input" type="text" /><input class="v6_33 invisible-input" type="text" />
+      <input class="v6_25 invisible-input" type="text" /><input class="v6_10 invisible-input" type="text" /><input class="v6_16 invisible-input" type="text" /><input class="v6_18 invisible-input" type="text" />
+      <input class="v6_12 invisible-input" type="text" /><input class="v9_20 invisible-input" type="text" /><input class="v9_28 invisible-input" type="text" /><input class="v9_22 invisible-input" type="text" />
+      <input class="v9_24 invisible-input" type="text" /><input class="v9_26 invisible-input" type="text" /><input class="v9_30 invisible-input" type="text" /><input class="v9_31 invisible-input" type="text" />
+      <input class="v9_32 invisible-input" type="text" /><input class="v9_33 invisible-input" type="text" /><input class="v9_34 invisible-input" type="text" /><input class="v9_36 invisible-input" type="text" />
+      <input class="v9_37 invisible-input" type="text" /><input class="v9_38 invisible-input" type="text" /><input class="v9_39 invisible-input" type="text" /><input class="v9_40 invisible-input" type="text" />
+      <input class="v9_42 invisible-input" type="text" /><input class="v9_43 invisible-input" type="text" /><input class="v9_44 invisible-input" type="text" /><input class="v9_45 invisible-input" type="text" />
+      <input class="v9_46 invisible-input" type="text" /><input class="v12_109 invisible-input" type="text" />
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- replace Figma rectangle divs in the-one-ring layout with inputs
- add a CSS rule for `invisible-input` so these fields don't show borders

## Testing
- `pytest -q`
- `tidy -errors -quiet static/the-one-ring/index.html`

------
https://chatgpt.com/codex/tasks/task_e_684de880e08c8329a16c4edc4462e314