### PR TITLE
Add .codexignore to limit patch scope

### DIFF
--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,4 @@
+*
+!static/
+!static/the-one-ring/
+!static/the-one-ring/**


### PR DESCRIPTION
## Summary
- ignore all files so only `static/the-one-ring` is included when building patches

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684debfb73ec8329b2190fa5f900a98f