### PR TITLE
Restrict container contents to static/the-one-ring

### DIFF
--- a/.codexignore
+++ b/.codexignore
@@ -2,8 +2,9 @@
 *
 
 # Only allow this folder
-!the-one-ring/
-!the-one-ring/**
+!static/
+!static/the-one-ring/
+!static/the-one-ring/**
 
 # Common bloat/exclusions
 node_modules/


### PR DESCRIPTION
## Summary
- update `.codexignore` to only keep `static/the-one-ring`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df5e461d48329a06691ae61dd0bd3