### PR TITLE
Hide Figma rectangles in The One Ring

### DIFF
--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -82,6 +82,11 @@
       outline: none;
       border-color: #888;
     }
+
+    /* Hide Figma rectangles */
+    .v3_19 {
+      display: none !important;
+    }
   </style>
 </head>
 


### PR DESCRIPTION
## Summary
- hide Figma rectangles on `the-one-ring/index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e38fe4ae083299589f8715ecb5427