### PR TITLE
Fix CSS path for Flask static serving

### DIFF
--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -6,7 +6,8 @@
   <title>The One Ring</title>
 
   <!-- Link to Figma Exported Styles -->
-  <link href="css/main.css" rel="stylesheet" />
+  <!-- Use /static path so Flask can serve CSS correctly -->
+  <link href="/static/the-one-ring/css/main.css" rel="stylesheet" />
 
   <style>
     body {


### PR DESCRIPTION
## Summary
- fix broken CSS reference for the `/the-one-ring` route
- keep existing docs version for GitHub Pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e46ce32f083298ad383ea4d36f598