### PR TITLE
Make Figma rectangles editable

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2025,13 +2025,15 @@ body {
   overflow: hidden;
 }
 .invisible-input {
-  background: none;
+  background-color: transparent;
   border: none;
   outline: none;
+  color: black;
+  font-size: 14px;
+  font-family: inherit;
   width: 100%;
   height: 100%;
-  position: absolute;
-  color: #f0f0f0;
-  font-size: inherit;
-  font-family: inherit;
+  padding: 0;
+  margin: 0;
+  text-align: center;
 }

--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -84,10 +84,6 @@
       border-color: #888;
     }
 
-    /* Hide Figma rectangles */
-    .v3_19 {
-      display: none !important;
-    }
   </style>
 </head>
 


### PR DESCRIPTION
## Summary
- remove style rule hiding Figma layout so input rectangles are visible
- style `.invisible-input` to make fields clickable and styled

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4bc152248329be83fb07b6450d2d