### PR TITLE
Fix input visibility in Figma layout

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2036,4 +2036,15 @@ body {
   padding: 0;
   margin: 0;
   text-align: center;
+  position: absolute;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+/* Ensure background images don't block input interaction */
+.v5_3,
+.v5_6,
+.v6_37,
+.v12_109 {
+  z-index: 1;
 }


### PR DESCRIPTION
## Summary
- adjust CSS to raise text input elements above background images

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e50864e2483298586d7c6d4d662af