### PR TITLE
Style tweaks for One Ring layout

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2026,7 +2026,7 @@ body {
 }
 .invisible-input {
   background-color: transparent;
-  border: none;
+  border: 1px solid #fff;
   outline: none;
   color: black;
   font-size: 14px;
@@ -2047,4 +2047,16 @@ body {
 .v6_37,
 .v12_109 {
   z-index: 1;
+}
+
+/* Add white borders to all rectangles that don't use background images */
+div[class^="v"]:not(.v5_3):not(.v5_6):not(.v12_109) {
+  border: 1px solid #fff;
+}
+
+/* Hide decorative background images */
+.v5_3,
+.v5_6,
+.v12_109 {
+  opacity: 0;
 }


### PR DESCRIPTION
## Summary
- show white borders around all layout rectangles
- hide background placeholder images in The One Ring app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e544b6e6c8329a6dd278d919371fb