### PR TITLE
Fix alignment of rectangles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,10 @@
       flex: 1;
       overflow-y: auto;
       background-color: #111;
-      padding: 20px;
+      /* Ensure absolutely positioned elements inside follow the coordinates
+         defined in main.css by making this container the positioning context */
+      position: relative;
+      padding: 0;
     }
 
     /* Right Panel: Chatbot */

--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -26,7 +26,10 @@
       flex: 1;
       overflow-y: auto;
       background-color: #111;
-      padding: 20px;
+      /* Ensure absolutely positioned elements inside follow the coordinates
+         defined in main.css by making this container the positioning context */
+      position: relative;
+      padding: 0;
     }
 
     /* Right Panel: Chatbot */


### PR DESCRIPTION
## Summary
- make the Figma layout container the positioning context
- remove padding that offset absolute elements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e570bcb5483298d071f849220cd75