### PR TITLE
Stop tab from moving Figma inputs

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -2026,7 +2026,7 @@ body {
 }
 .invisible-input {
   background: none;
-  border: none;
+  border: 1px solid #000;
   outline: none;
   width: 100%;
   height: 100%;

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,10 @@
       flex: 1;
       overflow-y: auto;
       background-color: #111;
-      padding: 20px;
+      /* Ensure absolutely positioned elements inside follow the coordinates
+         defined in main.css by making this container the positioning context */
+      position: relative;
+      padding: 0;
     }
 
     /* Right Panel: Chatbot */

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,6 +1,17 @@
 const messages = document.getElementById("messages");
 const input = document.getElementById("userInput");
 
+// Prevent Tab from changing focus between Figma inputs
+document.querySelectorAll(".invisible-input").forEach((el) => {
+  // Remove Figma inputs from the normal tab order
+  el.tabIndex = -1;
+  el.addEventListener("keydown", (e) => {
+    if (e.key === "Tab") {
+      e.preventDefault();
+    }
+  });
+});
+
 function appendMessage(sender, text, className) {
   const msg = document.createElement("div");
   msg.classList.add("message", className);

--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2026,7 +2026,7 @@ body {
 }
 .invisible-input {
   background-color: transparent;
-  border: 1px solid #fff;
+  border: 1px solid #000;
   outline: none;
   color: black;
   font-size: 14px;
@@ -2051,7 +2051,7 @@ body {
 
 /* Add white borders to all rectangles that don't use background images */
 div[class^="v"]:not(.v5_3):not(.v5_6):not(.v12_109) {
-  border: 1px solid #fff;
+  border: 1px solid #000;
 }
 
 /* Hide decorative background images */

--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -26,7 +26,10 @@
       flex: 1;
       overflow-y: auto;
       background-color: #111;
-      padding: 20px;
+      /* Ensure absolutely positioned elements inside follow the coordinates
+         defined in main.css by making this container the positioning context */
+      position: relative;
+      padding: 0;
     }
 
     /* Right Panel: Chatbot */

--- a/static/the-one-ring/script.js
+++ b/static/the-one-ring/script.js
@@ -1,6 +1,17 @@
 const messages = document.getElementById("messages");
 const input = document.getElementById("userInput");
 
+// Prevent Tab from shifting focus between Figma inputs so their positions stay fixed
+document.querySelectorAll(".invisible-input").forEach((el) => {
+  // Remove Figma inputs from the normal tab order
+  el.tabIndex = -1;
+  el.addEventListener("keydown", (e) => {
+    if (e.key === "Tab") {
+      e.preventDefault();
+    }
+  });
+});
+
 function appendMessage(sender, text, className) {
   const msg = document.createElement("div");
   msg.classList.add("message", className);


### PR DESCRIPTION
## Summary
- ensure left panel is the positioning context for Figma elements
- darken invisible input borders
- keep absolute inputs in place by removing them from the tab order

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e570bcb5483298d071f849220cd75