### PR TITLE
Fix width/height for Figma inputs

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -2031,12 +2031,11 @@ body {
   color: black;
   font-size: 14px;
   font-family: inherit;
-  width: auto;
-  height: auto;
   padding: 0;
   margin: 0;
   text-align: center;
   position: absolute;
+  display: inline-block;
   z-index: 10;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- remove width/height overrides from `.invisible-input`
- allow absolutely positioned inputs to size correctly by using `display: inline-block`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e729375888329836026300f0c9d08