### PR TITLE
Style Figma rectangles as visible text boxes

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -27,93 +27,83 @@ body {
   left: 0px;
   overflow: hidden;
 }
+.v25_9,
+.v25_11,
+.v25_13,
+.v25_15,
+.v25_17,
+.v25_19,
+.v25_21,
+.v25_8,
+.v25_7 {
+  background: #ffffff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #000;
+  padding: 2px 4px;
+  box-sizing: border-box;
+  position: absolute;
+}
+
 .v25_9 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 301px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_11 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 276px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_13 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 252px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_15 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 227px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_17 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 203px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_19 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 178px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_21 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 154px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_8 {
   width: 360px;
   height: 20px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 326px;
   left: 154px;
-  overflow: hidden;
 }
+
 .v25_7 {
   width: 424px;
   height: 50px;
-  background: rgba(217,217,217,0);
-  opacity: 1;
-  position: absolute;
   top: 55px;
   left: 435px;
-  overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- update CSS styles for `.v25_*` classes to look like text boxes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e88731e18832983a1d1cdaa26cd59