### PR TITLE
Fix Figma panel layout

### DIFF
--- a/static/the-one-ring/css/main.css
+++ b/static/the-one-ring/css/main.css
@@ -4,28 +4,20 @@
 body {
   font-size: 14px;
 }
-.v25_23 {
-  width: 100%;
-  height: 999px;
-  background: rgba(255,255,255,0);
-  opacity: 0.5;
+.container {
   position: relative;
-  top: 0px;
-  left: 0px;
-  overflow: hidden;
+  width: 960px;
+  height: 1024px;
+  margin: 0 auto;
+  background: transparent;
 }
 .v25_3 {
+  position: absolute;
   width: 100%;
-  height: 999px;
-  background: url("../images/v25_3.png");
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: left top;
-  opacity: 1;
-  position: relative;
-  top: 0px;
-  left: 0px;
-  overflow: hidden;
+  height: 100%;
+  background: url("../images/v25_3.png") no-repeat center center;
+  background-size: cover;
+  z-index: 0;
 }
 .v25_9,
 .v25_11,
@@ -43,6 +35,7 @@ body {
   padding: 2px 4px;
   box-sizing: border-box;
   position: absolute;
+  z-index: 1;
 }
 
 .v25_9 {

--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -93,7 +93,7 @@
 <body>
   <!-- LEFT PANEL: Figma Layout -->
   <div class="left-panel">
-    <div class="v25_23">
+    <div class="container">
       <div class="v25_3"></div>
       <input class="v25_7" type="text" />
       <input class="v25_8" type="text" />


### PR DESCRIPTION
## Summary
- add a container element for the Figma layout
- keep the image fixed behind inputs and stack input boxes above it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8f656e588329a90f4141f5c162b6