### PR TITLE
Extract text from PDF documents

### DIFF
--- a/extract_ring_pdfs.py
+++ b/extract_ring_pdfs.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+import fitz  # PyMuPDF
+
+
+def extract_text_from_pdfs(input_dir: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for pdf_path in input_dir.glob('*.pdf'):
+        text_parts = []
+        with fitz.open(pdf_path) as doc:
+            for page in doc:
+                text_parts.append(page.get_text())
+        output_file = output_dir / f"{pdf_path.stem}.txt"
+        with output_file.open('w', encoding='utf-8') as f:
+            f.write("\n".join(text_parts))
+
+
+if __name__ == "__main__":
+    input_directory = Path('documents/the-one-ring')
+    output_directory = Path('static/text/the-one-ring')
+    extract_text_from_pdfs(input_directory, output_directory)

--- a/static/text/the-one-ring/the-one-ring-starter-adventures.txt
+++ b/static/text/the-one-ring/the-one-ring-starter-adventures.txt
@@ -1,0 +1,2064 @@
+the adventures
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+LEAD WRITER
+James Michael Spahn
+ADDITIONAL WRITING
+Francesco Nepitello, Jacob Rodgers
+GAME DESIGNERS
+Francesco Nepitello and Marco Maggi
+ADDITIONAL RULES DEVELOPMENT
+Michele Garbuggio
+CONCEPT ART
+Alvaro Tapia
+COVER ART
+Martin Grip
+OTHER ART
+Alvaro Tapia, Martin Grip, Jan Pospíšil, Niklas Brandt, Henrik Rosenborg,  
+Antonio De Luca, Federica Costantini, Melissa Spandri, Giuditta Betti
+GRAPHIC DESIGN
+Christian Granath, Dan Algstrand, Niklas Brandt
+MAPS
+Francesco Mattioli
+EDITORS
+John Marron, Jacob Rodgers
+PROJECT MANAGERS
+Martin Takaichi, Tomas Härenstam
+BRAND MANAGER
+Robert Hyde / Sophisticated Games
+EVENT MANAGER
+Anna Westerling
+PR MANAGER
+Boel Bermann
+STREAMING
+Doug Shute, Matthew Jowett
+ISBN
+978-91-89143-48-7
+SPECIAL THANKS TO
+Claudio Muraro and Umberto Pignatelli
+PLAYTESTING OF THE 2ND EDITION
+Adam Rawson, Agnes Rudbo, Amanda Stenback, Andreas Lundström, Anna Ave, Charlie Conley, Chiara Ave, 
+Dan Price, Daniel Raab, Dennis Detwiller, Francisca Hoogenboom, Giuliano Nepitello, Kathleen Kiker, 
+Kyle Wood, Lorenzo Perassi, Luca Donati, Maja Emilie Søgaard Widerberg, Maner Samuel, Marco Beltramino, 
+Michael Kiker, Michela Baù, Peter Bergman, Peter Link, Ric Wagner, Stephen Buck, Steven Nguyen Dinh, 
+Umberto Pignatelli, Vanessa Ratschinske.
+The One Ring, Middle-­earth, and The Lord of the Rings and the characters, items, events, and places therein  
+are trademarks or registered trademarks of the Saul Zaentz Company d/b/a Middle-­earth Enterprises (SZC)  
+and are used under license by Sophisticated Games Ltd. and their respective licensees. All rights reserved.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+THE CONSPIRACY
+ 
+                         OF	
+  
+THE RED BOOK
+“Then we formed our conspiracy; and as we were serious, too, 
+and meant business, we have not been too scrupulous.”
+James Smith (Order #47812382)
+
+ADVENTURES
+4
+introduction
+In a hole in the ground there lived a Hobbit.
+his volume contains five adventures, to be played 
+using the pre-­generated characters provided in 
+this boxed set. While they can be played as sep-
+arate scenarios, the adventures can be linked 
+together, allowing the players to explore the width and 
+breadth of the Shire and beyond. They all take place in or 
+around the year 2960 of the Third Age (or 1360 by Shire 
+Reckoning), though the date is flexible and the Lore­master 
+can adjust it if need be. 
+When run as linked scenarios, the Lore­master should run 
+A Conspiracy Most Cracked first, Involuntary Postmen as the next 
+to last, and To Soothe a Savage Beast as the finale. The remain-
+ing adventures can be run in any order.
+The Lore­master can reference the locations detailed 
+in the adventures by consulting the geography section 
+of The Shire, and make use of the various suggestions, 
+rules, and tables found therein.
+With the exception of Expert Treasure Hunters and To Soothe 
+a Savage Beast, all adventures share the same approximate 
+level of difficulty. 
+using the pre‑generated 
+characters
+Included in this box set are eight pre-­generated Player-­heroes. 
+Initially, the players may each select one of the six ­Hobbits: 
+Drogo Baggins, Paladin Took, Rorimac Brandybuck, Primula 
+Brandybuck, Esmeralda Took, and Lobelia Bracegirdle. Lore­
+masters should allow the players the opportunity to review 
+each of these pre-­generated characters and choose which one 
+they’d like to play through the scenarios detailed in this book. 
+As the story unfolds, two new heroes will become avail-
+able as Player-­heroes. The Lore­master is encouraged to keep 
+these new heroes a secret until they become available, so as 
+to not spoil the surprise for the players. These additional pre-­
+generated characters are the Dwarf Balin, son of Fundin, and 
+Bilbo Baggins himself!
+James Smith (Order #47812382)
+
+A Conspiracy Most Cracked
+5
+a conspiracy most cracked
+“… we formed our conspiracy; and as we were serious, too, and meant business …”
+Mad Baggins is at it again, and has gathered in Bag End a new 
+cabal of adventurous spirits whom he has named the Con-
+spirators of the Red Book (the Player-­heroes). In an effort to 
+gather notes for his book, he has asked these friends, under 
+promise of payment and a bit of adventure, to help him con-
+firm some important details about the history of the Shire 
+and its people. The first and most important item is a map 
+of the Shire that is kept locked away in the Mathom-­house, 
+at Michel Delving, which he believes was sketched by none 
+other than the Old Took himself! These conscripted con-
+spirators will need to travel there, slip past any watch with-
+out arousing suspicion, and pilfer the ancient map before 
+returning to Bag End.
+This should be the first scenario run, as it sets the 
+stage for all the others. It occurs during the spring or 
+summer of 1360 Shire Reckoning (2960 Third Age). 
+The action begins at Bag End, and then moves on to 
+Michel Delving and back.
+part one: off into the blue
+The first part of this adventure is little more than a ­Hobbit 
+walking party, an easy entry into the life of an errant adven-
+turer. It will take the Player-­heroes over the river west of Bywa-
+ter and to the village of Waymeet, where they’ll need to avoid 
+local gossip mongers. 
+The Lore­master is encouraged to read or paraphrase the 
+following text to open the adventure.
+After quite a long walk under stars that have come out 
+blazing and bright after an afternoon of heavy rain, you’ve 
+finally come to the round green door of Bag End, the home 
+of the strange and famous Bilbo Baggins. Standing there 
+upon the mat, you find yourself surrounded by distant 
+relations. It seems as though Bilbo called for a collection 
+of cousins to join him this evening. Just as one of you is 
+about to ring the bell, the door is pulled open and you see 
+standing in the front hall none other than Master Baggins 
+himself. He offers each of you an energetic greeting and 
+quickly ushers you in with a plethora of welcomes, thank 
+yous, and lovely to see yous. 
+James Smith (Order #47812382)
+
+ADVENTURES
+6
+Before you can gather your wits about you, you’ve been 
+swept into the warm embrace of Bag End, and led into the 
+parlour where a lovely fire, fresh mugs of ale, plates of dain-
+ties, and several cushioned chairs and sofas offer a much-­
+needed spot of rest and relaxation. Bilbo, a twinkle in his 
+eye, ushers you each into a seat but takes none for himself. 
+A few moments after you’ve finished the first plate of food, 
+the obviously excited Master Baggins can no longer contain 
+himself. He places one hand behind his back and another in 
+his vest pocket, standing tall to ensure he has your attention.
+“You are all, undoubtedly, curious as to why I’ve called 
+you here this evening. Well,” he leans in, the firelight caus-
+ing the twinkle in his eye to dance merrily. His hand sweeps 
+from behind his back towards the parlour window. “I am 
+hoping you will partake in a little adventure! Nothing so 
+grand as my own, I’m afraid: but in return for your aid, I 
+will provide each of you with a place in my memoirs, and a 
+fair share of my eternal gratitude.”
+He grabs a glass of wine off the table and takes a sip, 
+pausing for effect. “Now, I know what you’re thinking: ‘There 
+goes Old Bilbo again, taking after that Wizard Gandalf and 
+sending you ­Hobbits off into the blue. Well, I can assure you it 
+is nothing of the sort. Just a little trip to Michel Delving and 
+back to recover what one might call a family heirloom from 
+the Mathom-­house: a map of the Shire supposedly made by 
+the Old Took himself, with all sorts of precious annotations. 
+Now, I’ve sent many letters to the custodian, Malva Slowfoot, 
+asking if I could have it back, even offering fairly generous 
+donations: but for some reason, she has provided no replies. 
+So, I thought that we needn’t tell her or her husband 
+— after all, we’re talking about something that belonged to 
+my grandfather, and that would not be out of place here, in 
+Bag End. Most of all, we needn’t alert that pesky dog that 
+the Slowfoots have set to guard the place! Sharp as a tack, 
+that beast, and he sniffs me out every time I’ve come near. 
+Besides, I know some of you place more value on local gos-
+sip than others — and even just being seen at night in the 
+Company of ‘Mad Baggins’ might be enough to ruin your 
+reputation forever. But for those of you with spirit — which 
+I know you all have in spades, or I’d have not called you 
+here tonight — won’t you aid me on this errand of particu-
+lar importance, my fellow conspirators?”  
+Bilbo will offer each of them a fine night’s rest in one of the 
+many spare bedrooms of Bag End, and a hearty breakfast, 
+before telling them he plans on sending them out the door 
+after second breakfast. 
+To keep the trip away from the prying eyes of the nosy 
+­Hobbits of ­Hobbiton and Bywater, Bilbo has laid out a path 
+for the conspirators, instructing them to head north from 
+Bag End into Overhill and turn west across the country for a 
+few miles, before crossing a shallow point in the Water. Then, 
+after crossing the Bywater Road, they will reach the East Road 
+and set out west towards Waymeet, where they’ll take rest for 
+the evening before arriving at Michel Delving the next day.
+GETTING ACROSS THE WATER 
+The morning dawns bright and clear, perfect for a nice walk 
+about the Shire. The first true obstacle reveals itself soon 
+after they leave Overhill — the Water has become swifter with 
+recent rain, and the shallow ford where Bilbo told them to 
+cross looks a bit more treacherous. 
+The Player-­heroes must now consider their circumstances 
+and find a solution.
+Crossing the Water requires an ATHLETICS roll. 
+Player-­heroes who pass it with one or more  icons 
+swim across with flair, or can help others who find it 
+harder to make their way across. ­Hobbits who fail their 
+ATHLETICS roll return to the near bank, coughing and 
+spluttering, and fully soaked. 
+Bilbo Baggins
+James Smith (Order #47812382)
+
+A Conspiracy Most Cracked
+7
+If the Player-­heroes look for other means of crossing, 
+a successful SCAN roll allows them to spot a large hol-
+low log on the other side of the Water, which could 
+easily bear the weight of a ­Hobbit. 
+To retrieve the log, the ­Hobbits must summon their adven-
+turous side and get inventive. 
+For example, the feat can be accomplished by using 
+a rope and hook (a CRAFT roll) or even by shooting 
+an arrow with an attached line (a BOWS roll). Success 
+means that they manage to get a good hold on the log 
+and can easily pull it to themselves. Another way could 
+be to have the best swimmer among them get to the 
+other side, fetch the log and swim back. 
+Dry or soaked, the ­Hobbits will eventually find a way, and 
+reach Waymeet after a good walk on the East Road.
+WELL MET IN WAYMEET
+Waymeet itself is quite active on the evening when the Player-­
+heroes arrive, as the tables set outside the Walking Party Inn 
+are still occupied, thanks to the fair weather and lengthen-
+ing daylight hours. The locals are polite, though very curious 
+about what brings a crowd of ­Hobbits so diverse this far west 
+at such a late hour.
+Avoiding inquiries as to the nature of their business 
+without offending the locals can be done with a suc-
+cessful RIDDLE roll. On a failure, they reveal a bit too 
+much about their involvement with Mad Baggins, and 
+the conversation soon dries up, among puzzled and 
+disapproving looks. 
+Finding lodging for the night proves a little harder… It seems 
+that all beds at the Walking Party Inn are taken, booked by 
+a group of pipe-­weed merchants headed for Longbottom. 
+Asking around, they are pointed to a local farmer, one Baldo 
+Bunce, who appears to have some spare room in his stables. 
+Bunce offers to let the Player-­heroes sleep in his premises 
+(which are comfortable enough, given the warm nights and 
+soft hay) — but only if they can drive off a huge and menacing 
+owl that’s been troubling Gertrude, his poor old plow mule.
+If the players accept, Bunce offers to pay for their meal 
+that night at the Walking Party, before leading them to his 
+farm, less than a quarter mile south of the Waymeet cross-
+roads. He shows them into the barn and then brings them 
+blankets, along with a small basket of some leftover bread 
+and ale from the afternoon as an evening snack. Baldo never 
+noses into their business and apologizes profusely for his lack 
+of hospitality, saying he doesn’t have much room inside his 
+small cottage. Nevertheless, he fully expects them to have that 
+damned owl gone by morning. When Baldo is done talking, 
+an eerie hoot rings out through the barn, as if on cue, and 
+the tiny mule sitting idly in the rear of the place stirs.
+The Player-­heroes can get rid of the great owl if they 
+politely inform him with a COURTESY roll that there 
+are no more mice in the barn and that he’s bother-
+ing Gertrude. If the roll is passed, the owl flies off 
+almost as if he understood them. Alternatively, an 
+AWE roll can serve as a form of intimidation, as will 
+a HUNTING roll.
+If the large bird is scared off rather than politely urged, it 
+leaves, but first looks pointedly from the Player-­heroes to Ger-
+trude, the mule, and hoots at her to which she replies with a 
+brief bray. It seems almost as if the two are talking! The owl 
+is commenting to the mule about how he was treated by the 
+Player-­heroes and will inform the other animals he knows 
+about these rude ­Hobbits (the Lore­master should remember 
+to make any future interactions with the beasts of the Shire 
+more difficult).
+The rest of the evening passes uneventfully, and a few 
+minutes after the rooster crows, Bunce wakes the characters 
+and bids them a polite but firm farewell. 
+part two: mathoms 
+of michel delving
+Setting out from Waymeet, the conspirators will arrive at 
+Michel Delving by the end of the day. Here, they will begin 
+their adventure in earnest, having to confusticate Bounders, 
+confuse custodians, and face curious canines as they attempt 
+the clandestine recovery of the Old Took’s map from the 
+Mathom-­house. Once the deed is done, they’ll need to make 
+a hasty retreat from Michel Delving before their dubious 
+activities are noticed!
+After a bit of a stiff sleep in Bunce’s barn and a long west-
+ward walk, the conspirators finally reach the edges of Michel 
+Delving upon the White Downs. The Lore­master may read 
+or paraphrase the following text.
+You pass the spot where a southward path leads off from 
+the main course of the East Road, just as the sun sets and 
+the first stars begin to reveal themselves. Ahead, you get a 
+good look at Michel Delving upon the White Downs. Quite 
+a bit larger than ­Hobbiton, it is a tightly packed collection 
+of homes built of wood, brick, and stone, and the occa-
+sional ­Hobbit-­hole. But as the last of its people go about 
+James Smith (Order #47812382)
+
+ADVENTURES
+8
+their evening business, your eye cannot help but be drawn 
+to the massive smial to one side of the great cobblestone thor-
+oughfare running through the centre of town: the Town Hole, 
+seat of the Mayor of the Shire. 
+But more important to your business is what lies south 
+of the Town Hole, on an adjacent hillock not quite so tall 
+and green — it is a large wooden building with a great red 
+round door that is connected to the main road by way of a 
+small stone path. This is the Mathom-­house, the museum 
+of the Shire, your destination.
+As candles flicker to life behind windows, and 
+­Hobbitfolk settle in for the evening, you notice a handful 
+of ­Hobbits carrying stout cudgels and tiny lanterns strolling 
+about. Bounders, undoubtedly making their usual rounds. 
+Best to avoid them, though, lest your mischief be discovered 
+and thwarted.
+BURGLARS IN MICHEL DELVING
+The conspirators face their greatest challenge so far — to 
+reach the Mathom-­house without anyone noticing, and to 
+gain access to it.
+To get up to the Mathom-­house without the Bounders 
+noticing requires each character to pass a STEALTH 
+roll. Failure means a Bounder approaches and ques-
+tions them. 
+The Bounder approaching the conspirators is Ada Burrows, 
+a young and enthusiastic ­Hobbit from Little Delving. This 
+is one of her first assignments, and she takes her duty to 
+ask questions of wanderers found outside after nightfall 
+very seriously. 
+Convincing Ada that they are doing nothing untow-
+ard requires the Player-­heroes to make a roll of PER-
+SUADE — or RIDDLE, should they try to confuse her 
+with clever words or distractions.
+Failing to convince Ada worsens the conspirators' predica-
+ment considerably — the Bounder questions them extensively 
+before she lets them go, and then she walks to the Mathom-­
+house and locks the front door! Now it will be impossible to 
+gain entrance through it. 
+Inspecting the grounds surrounding the Mathom-­house 
+for other ways to enter reveals that, though the door is locked 
+and the windows barred, there is a small skylight opening on 
+the roof. Additionally, at some distance from the Mathom-­
+house and sticking out of the side of the hill upon which the 
+museum sits is an old door that may lead into the basement 
+of the establishment.
+Climbing up to the roof requires a roll of ATHLETICS. 
+Failure results in a fall causing the loss of 3 Endur-
+ance points. If two or more Player-­heroes fail the roll, 
+they get caught up in a tumbled mess and everyone 
+lands with a loud clatter that alerts the surprise guest 
+waiting inside! 
+Once up there, the conspirators find the skylight to be 
+unlocked. Landing safely on the floor inside the main hall 
+of the Mathom-­house requires a second ATHLETICS roll (for 
+the consequences of failure, see above).
+Characters choosing to try the door on the side of the hill 
+find that it leads to a narrow, cluttered underground chamber, 
+a basement filled with all kinds of forgotten trinkets and thick 
+cobwebs. In fact, a small pack of rats has taken up residence 
+here, fearful of the guardian that lives on the ground floor. 
+Scaring the rats off causes them to scurry away noisily 
+and awaken the guard dog: avoiding this requires a 
+successful STEALTH roll. 
+A trapdoor leading into the Mathom-­house opens in the ceil-
+ing of the cellar, above a massive pile of antique pots and 
+pans. To move them aside carefully requires another success-
+ful STEALTH roll, lest they clatter to the floor and make all 
+manner of noise (and awaken the guardian). 
+THE MATHOM-­HOUSE, INSIDE AND OUT
+Whether they entered the Mathom-­house by way of the 
+unlocked main door, or through the roof or the basement, 
+the conspirators find themselves inside a great, high-­ceilinged 
+series of rooms, containing an impressive display of artefacts 
+from across the history of the Shire. Shelves of books chroni-
+cling family genealogies and recipes passed down for genera-
+tions line the walls, while a set of perfectly polished diamond 
+studs are set on a pedestal under glass, and a pair of strange 
+crossed walking sticks are mounted on one wall. Countless 
+other knick-­knacks and mathoms are on display. From old 
+brass buttons mounted on a velvet board, to a gleaming coat 
+of silver rings set to rest on a post in the corner. Though a 
+wonder to behold, it is going to take a bit of doing to find 
+the Old Took’s map in this collection!
+But the most concerning sight appearing in front of the 
+searching conspirators as they enter is the grey and brown 
+furred terrier, the fearsome guard dog kept by Malva the 
+custodian! If the Player-­heroes gained access to the museum 
+without making noise, the dog is curled up asleep under a 
+writing desk, letting out heavy snores. If they made noise 
+entering, the terrier (whose name is “Firework”) is well 
+awake.
+James Smith (Order #47812382)
+
+A Conspiracy Most Cracked
+9
+If the dog is asleep, the Player-­heroes may search for 
+the map, but must do so quietly. This requires three 
+successful SCAN rolls — failing twice means they make 
+noise. Once three successful rolls are achieved, the 
+conspirators locate the Old Took’s map — buried 
+behind a stack of cookbooks on the bottom shelf of 
+one of the bookcases. It is in surprisingly good con-
+dition, if a bit creased.
+If the dog is awake, or if the Player-­heroes rouse him 
+by failing two SCAN rolls, the dog eyes them before 
+letting out an inquisitive bark. He is not fierce, but 
+friendly and energetic. Unfortunately, he expresses 
+his excitement at having found new friends by bark-
+ing. Calming the dog requires a COURTESY roll. If 
+the roll succeeds, then the dog is lulled back to sleep 
+for the entire search.
+If Firework is not pacified, his barking rattles the nerves of 
+the conspirators, who fear the noise will draw the attention of 
+some local ­Hobbit — a Bounder, or, worse, a Shirriff! 
+Actually, no one is alarmed by Firework’s antics, and 
+the only consequence of his barking is that the impro-
+vised burglars all lose 1 point of Hope due to fear of 
+being discovered!
+SLIPPING OUT OF TOWN
+Once they have what they came for, the conspirators can easily 
+unlock the front door from the inside and escape. 
+If Firework has been alerted, slipping out of Michel Delv-
+ing will require some further planning to avoid someone 
+noticing a group of sneaking ­Hobbits followed by a bark-
+ing dog. If the Player-­heroes are not wary on the way out, a 
+Bounder or two might still notice them slip away, and remem-
+ber their faces in days to come. 
+Finally, if they were not explicitly careful, the conspirators 
+have in all likelihood left evidence that something is missing 
+from the Mathom-­house. By mid-­morning of the next day, 
+the news that someone broke into the Mathom-­house is all 
+over Michel Delving, and within a few more it spreads across 
+the Westfarthing. 
+epilogue
+Once the conspirators return to Bag End, the Lore­master 
+should read the following text:
+After your successful recovery of the Old Took’s map of the 
+Shire and swift journey home, you’re greeted by the green door 
+of Bag End being thrown open like a pop gun to reveal a 
+grinning Bilbo standing on the doorstep, walking stick in 
+hand. “You found it! Wonderful, simply wonderful!”
+Though eager, Bilbo ushers you in with a hasty wave of 
+his hand. “Come on, we’ll need to review my grandfather’s 
+map quickly tonight if we’re to set off on our next adventure! 
+This remarkable find of yours makes me believe I’m quite 
+ready for another adventure!”
+Bilbo and the other conspirators can relax for a time. Bilbo 
+prepares a fine meal for everyone and asks about the whole 
+affair. After hearing the story, he cannot help but laugh, add-
+ing that he is ready to join them on their next adventure! 
+Bilbo Baggins is now available to be chosen as a Player-­
+hero for the next adventure! The Lore­master should 
+give everyone in the play group the opportunity to 
+choose the veteran burglar as their character.
+STEALING MATHOMS
+The Lore­master is encouraged to remind any play-
+ers who bring up the idea of purloining any of 
+the more choice mathoms in the Mathom-­house 
+that such behaviour is unbecoming of a respect-
+able ­Hobbit. It’s one thing to take something on a 
+mission sponsored by Bilbo Baggins himself, but 
+quite another to take advantage of the situation! 
+Characters that even bring up such an act should 
+be ashamed of themselves.
+Malva Slowfoot 
+and Fireworks
+James Smith (Order #47812382)
+
+ADVENTURES
+10
+expert treasure hunters
+Old Took’s great-granduncle Bullroarer … charged the ranks of the 
+goblins of Mount Gram in the Battle of the Green Fields, and knocked 
+their king Golfimbul’s head clean off with a wooden club.
+His passion for history reignited by recent events, Bilbo studies 
+the Old Took’s map and discovers a clue concerning the where-
+abouts of the lost club of the Bullroarer. At once, he organizes 
+a trip into the Northfarthing, where the clue seems to point. 
+After questioning the ­Hobbits of Oatbarton, the quest leads 
+them further into the North Moors, and deeper into danger.
+This adventure can be played at any time after the 
+events of A Conspiracy Most Cracked, but before Invol-
+untary Postmen. If played in sequence, it is now the 
+spring of the year S.R. 1360.
+part one: on the road again
+With their efforts to purloin the Old Took’s map having been 
+successful, Bilbo is delighted. He invites everyone to stay for 
+several days as his guests at Bag End, during which time they 
+live in the lap of luxury. Though they never want for food and 
+drink, Bilbo remains locked up in his study, before eventually 
+coming out on the afternoon of the second day.
+Popping out of his study like a cuckoo from a clock, Bilbo 
+rushes into the parlour where you are all relaxing after a 
+fine second breakfast, map still clutched in his hand. “My 
+wonderful friends! You won’t believe what I’ve found on 
+the Old Took’s map: I believe I know where the club of Ban-
+dobras Took is located! Or at least the Old Took did. Or 
+rather he thought he did. Maybe he wasn’t sure.” He shakes 
+his head, as if to physically force the rambling thoughts 
+from his head. “Never you mind. I might need to do a bit 
+more research, but I was hoping for — nay, counting on 
+your help once again!”
+“After hearing all about your little adventure in Michel 
+Delving, I’d like a taste of adventure myself. It says here on 
+the map that the club of the Bullroarer may be somewhere 
+around the village of Oatbarton, in a place called Kings­
+worthy! Exciting, isn’t it? So, I was thinking perhaps in 
+return for my generous hospitality, we could take a walk 
+north and do a bit more investigating into the matter. Imag-
+ine it, being credited with being the ­Hobbits who found the 
+club of Bullroarer Took! Wait right here, I’ll run and get 
+you the right gear to suit a proper adventure!”
+And like that, Mad Baggins disappears in a flash 
+around the corner before returning as you all exchange 
+looks of excitement and confusion. He drops a large chest 
+before you, and smiles. “There you are! Take what you need. 
+There’s no knowing where we’ll be swept off to!” He turns 
+to dash off again but turns around back to you, almost 
+laughing at his own forgetfulness. “I’ve muddled my wits, 
+staying up all night making a copy of the Old Took’s map. 
+No need to damage the original, after all!” He shoves the 
+fresh copy at you before throwing open the front door to 
+Bag End and stepping out onto the road. “Come on!” he 
+cries, “We’d best be off!”
+James Smith (Order #47812382)
+
+Expert Treasure Hunters
+11
+OATBARTON INVESTIGATION
+To go to Oatbarton, the conspirators must first take the road 
+to Bywater to the south, and reach the East Road. Then, they 
+enter the Eastfarthing leaving behind the Three-­Farthing 
+Stone, and take the Northway Road to their left. It’s more 
+than a leisurely stroll to reach Oatbarton, taking more than 
+three days on average, but searching for the fabled club of 
+Bullroarer Took is certainly worth the effort (to enliven the 
+journey, the Lore­master can use the rules for ­Hobbit Walks 
+found on page 10 of The Shire).
+It’s almost midday when the conspirators catch sight of 
+the first houses of the village. It is spring, but the last hints of 
+winter still nip at their toes, making them particularly eager 
+for a hearty meal. Even before they take their first steps into 
+the cobblestone courtyard that serves as the heart of the vil-
+lage, they catch the scent of roast chicken and potatoes! The 
+hard-­working farmers of Oatbarton are gathered in the centre 
+of their village for their lunch, sitting at long tables, shaded 
+by large pavilions and tents. The search for the famous war 
+hero’s great club can wait…
+The villagers are happy to share their lunch with the 
+Player-­heroes, and as soon as they place a plate in front of 
+each of them, they start asking questions about what their 
+business may be so far north. Luckily for them, they are not 
+shy about answering questions themselves, especially if they 
+concern local history. 
+Gathering information about the Bullroarer and a 
+place called Kings­worthy requires 3 successful Skill 
+rolls, using AWE, COURTESY, ENHEARTEN, PERSUADE, 
+or RIDDLE. 
+The conspirators can pose their questions in any way they 
+see fit, but any Player-­hero who fails a roll cannot make any 
+more rolls to inquire further. The Lore­master can spread 
+the information described below among the Player-­heroes, 
+so that each of them uncovers a new clue and they can piece 
+together the information as a group.
+	
+♦Upon a first success, the Player-­heroes learn that the 
+‘Kings­worthy’ is an abandoned structure, about a day’s 
+travel into the North Moors. 
+	
+♦A second success allows the Player-­heroes to learn that 
+some of the rowdier local children play a game called 
+“Bullroarer’s Club” that seems to involve them rough-
+ing up one another with a stick from the field they 
+claim to be the artefact. 
+	
+♦A third and final success means they hear some 
+rumours about a ghost haunting the abandoned 
+Kings­worthy.
+KINGS­WORTHY
+Kings­worthy can be reached by taking a northward path from 
+Oatbarton, and walking for a full day across the North Moors 
+(see also The Shire, page 30 and beyond, for more about Kings­
+worthy and travelling across the North Moors). 
+Once it is in sight, the Player-­heroes may attempt to 
+identify the purpose of this large stone house and 
+round tower with a roll of LORE. On a success, they 
+conclude that it might have been a hunting lodge at 
+the time of the Kings in Norbury. 
+Upon a closer inspection, the conspirators find the place to 
+be deserted. They find evidence of it having been used as a 
+shelter by wanderers, but it certainly isn't inhabited regularly. 
+They spot a fresher set of tracks. A successful roll of 
+SCAN reveals that they quite clearly belong to one or 
+more ­Hobbits.
+But the most important find of the day is that no club hangs 
+over the large mantelpiece of Kings­worthy, but probably used 
+to. Above the cold fireplace is a large wooden plaque, bear-
+ing the signs of having been used to display a long object, as 
+tall as a ­Hobbit. 
+Careful examination and a successful CRAFT roll reveals 
+that something was mounted on the plaque and was 
+removed. A wooden chair sits near the fireplace, as if 
+someone used it to reach the spot above the mantelpiece. 
+Could the club have been stolen recently?
+BILBO’S GEAR
+Before setting out for Oatbarton, the characters can 
+draw from the equipment contained in the old trunk 
+provided by Bilbo. It contains basic travelling gear 
+such as cloaks, backpacks, pocket handkerchiefs, 
+other standard supplies, and few battered weap-
+ons. Among the weapons  are three clubs which can 
+also serve as walking sticks, a pair of small hunting 
+bows left behind by Dwarvish visitors (with arrows), 
+a short sword he had used for decoration instead 
+of warfare, a small axe for cutting wood, and one 
+dagger for each of them. Sting is not among the 
+weapons, as it is carried by Bilbo.
+James Smith (Order #47812382)
+
+ADVENTURES
+12
+TRACKING A THIEF IN THE NIGHT
+The most likely course of action for the Player-­heroes is to 
+set themselves to following the tracks they identified inside 
+Kings­worthy. Luckily for them, they are easily followed, as the 
+individual leaving them is moving with great haste.
+Unbeknownst to the conspirators, they are following 
+the tracks of one Mort Mudfoot, a farmer of Oatbarton. 
+He is after his daughter Myrtle, who disappeared yesterday 
+after having heard everyone in town talking about the club 
+of the Bullroarer — a very competitive player of Goblin 
+Nocking, a game involving balls, holes and the use of clubs, 
+Myrtle left town with the intention of securing for herself 
+the ‘most famousest’ club in ­Hobbit history, before some 
+stranger took it. Thinking this ‘Kings­worthy’ place to be 
+much closer to her home, she pressed on anyway, until she 
+reached it, finding that a club was indeed hanging over its 
+mantelpiece. Having found her prize, she took it and set off 
+on her way home. She is now wandering across the North 
+Moors, her father looking for her.
+The Player-­heroes can catch up with the beleaguered 
+father by succeeding in 3 HUNTING rolls. When they 
+do so, they spot the lean, brown-­haired ­Hobbit, des-
+perately following the tracks of his daughter as fast 
+as he can find them.
+If asked about the club of the Bullroarer, Mort will say he 
+doesn’t know anything about it but that Myrtle does love 
+to play Goblin Nocking with the other children, and that 
+must be why she came all the way out here this morning. 
+A life-­long resident of Oatbarton and a reasonable ­Hobbit 
+in his sixties, Mort is beside himself with concern. Myrtle is 
+his only child, and he fears even returning home to tell his 
+wife Marigold that she is missing because of how panicked 
+she will become. 
+Determined to find her no matter what it takes, Mort will 
+accept any help he is offered. He will tell little stories about 
+his daughter to any of the Player-­heroes that will listen. He 
+speaks of how adventurous she has always been, her love of 
+the stories of the Bullroarer, and how she dreams of explor-
+ing places beyond Oatbarton. 
+part two: shadows 
+and rumours
+The quest for the club of the Bullroarer has led the Player-­
+heroes into the North Moors, and now they are out there 
+at night, in search of a missing ­Hobbit girl. As they scour 
+the land, strange and potentially dangerous obstacles reveal 
+themselves.
+The Lore­master can read or paraphrase the following text.
+The night is clear and cool. A waxing moon and a veritable 
+symphony of starlight offers some light as you trek across the 
+lightly rolling landscape. But this is no well-­trodden road. 
+The ground is uneven, and your foot can easily be caught 
+in a hole or your legs grow weary as you plod through the 
+moss-­covered terrain. A long yawn escapes your mouth and 
+you fight off the weight of your own eyelids — all the while 
+searching for signs of the wayward ­Hobbit lass. Even in 
+this dim evening light, the growing concern is evident on 
+Mort’s drawn face.
+The Player-­heroes are pressing into the small hours 
+of the night, without any real opportunity to rest or 
+recover. As such, they all gain 3 Fatigue Points. They 
+can reduce the gain with a TRAVEL roll (a success 
+reduces the total Fatigue of a Player-­hero by 1, plus 1 
+point for each Success icon ).
+INTO THE NORTH MOORS 
+As the Player-­heroes scour the North Moors for some sign of 
+Myrtle, the Lore­master should ask them how they are going 
+about doing so, and determine which skill is appropriate 
+based on their preferred methods. 
+Myrtle Mudfoot
+James Smith (Order #47812382)
+
+Expert Treasure Hunters
+13
+Those attempting to identify an area where she may 
+have tried to find shelter in the night may make an 
+EXPLORE roll. 
+Characters looking for signs of where Myrtle may have 
+wandered in this wide landscape can make a HUNT-
+ING roll.
+Those looking for signs of anything out of the ordi-
+nary can attempt a SCAN roll. 
+EXPLORE. Clever Player-­heroes may consider that Myrtle 
+must have sought shelter somewhere in the wilderness 
+instead of wandering around in the dark. With a success-
+ful roll, the Player-­heroes do indeed discover the remnants 
+of a camp, but only with one or more Success icons 
+ do 
+they notice that it’s set up so skilfully that it can’t be the 
+work of a child. It even has a small fire pit, hand dug and 
+ringed with stones. 
+HUNTING. A success allows the Player-­hero to notice that 
+Myrtle’s meandering set of tracks is not leading her back to 
+Oatbarton. She is definitely lost. One or more Success icons  
+allows the characters to recover a tiny scrap of a pretty yellow 
+dress, which Mort confirms as being a colour that matches 
+the one Myrtle was last seen wearing.
+SCAN. A success reveals that there is another set of tracks 
+following those of Myrtle. With one or more 
+ icons, the 
+tracks are identified as large, booted footprints that do not 
+belong to any ­Hobbit. 
+Following this last set of tracks is easier than expected, and 
+does not require any further rolls. If the Player-­heroes follow, 
+after a while they even seem to be able to make out the sil-
+houette of a wanderer just on the edge of their vision, always 
+barely in sight. Player-­heroes succeeding in a roll of RIDDLE 
+realize that, given the figure’s long stride and apparent skill 
+at woodcraft, it is likely remaining in sight intentionally and 
+actually leading them.
+part three: dawn be stone!
+The climax of this adventure occurs once the Player-­heroes 
+follow the tracks they are after to the edge of a wide patch 
+of shrubland, where an unexpected adversary hides among 
+ancient ruins.
+The Lore­master can read or paraphrase the following text.
+Hours of pursuit mean that when you see the darker patch of 
+bracken and heather ahead, the sky has started to turn from 
+the deep blackness of night into the deep blue of the hours 
+before dawn. You’ve followed Myrtle’s tracks for miles now. 
+You’ve little doubt that she came this way. As you get closer, 
+you start noticing that the dark patch is not due simply to 
+a different vegetation — there are ancient stones jutting 
+out of the ground, low crumbling walls hinting that this 
+once was a very different place. A fort, a town maybe. Few 
+­Hobbits have seen this place, and as you take your first steps 
+forward among the stones, stories of kings and armour-­clad 
+warriors fill your mind.
+Just as you and your fellow conspirators are about to 
+explore the heather-­covered ruins, a rumbling growl seems 
+to rise from the ground itself! It’s a bellowing shout bear-
+ing some resemblance to human speech, echoing among 
+the ancient stones. You then hear a high, panicked voice 
+call out from nearby: “Shoo you old Troll! Go away! Go!” 
+Breaking through a thicket of brambles, you see none other 
+than Myrtle Mudfoot, who has scrambled up a ruined wall 
+and is swinging a heavy wooden club at a massive creature 
+looking like the grotesque imitation of a large Man — it’s 
+a Stone-­Troll! Between the two of them, leaning wearily 
+against a wall, is a cloaked stranger, hood thrown back 
+to reveal the rugged face of a Man with grey eyes, clutch-
+ing a large, bleeding gash across his shoulder that has all 
+but incapacitated him as he desperately tries to keep the 
+monster from reaching the child. The Troll is clearly angry, 
+and does not seem to have noticed you and your compan-
+ions. Myrtle, on the other hand, sees you and immediately 
+cries out for help. 
+Fighting an angry Stone-­Troll is quite a dangerous endeavour, 
+as the cloaked stranger has just found out. The creature is 
+large and powerful, but quite stupid. If the Player-­heroes take 
+on the Troll head to head, he fights ferociously, though he 
+flees once he’s Wounded or has lost half of his Endurance. 
+If the Player-­heroes attempt to trick the Troll with some 
+clever stratagem, they may succeed in buying enough time 
+and allow the light of the dawn surprise the creature. 
+A FATHER’S AID
+Mort can help the Player-­heroes. He is sharp-­eyed 
+— One single Player-­hero searching for evidence 
+of Myrtle gains (1d) to their rolls.
+James Smith (Order #47812382)
+
+ADVENTURES
+14
+To trick the Troll, the Player-­heroes need to accumu-
+late at least three successful Skill rolls, using HUNT-
+ING, RIDDLE, or SONG. The Troll hesitates, confused, 
+and does not attack for as long as the Player-­heroes 
+succeed at their rolls. Upon the first failure, the Troll 
+becomes enraged and attacks the nearest ­Hobbit with 
+a Favoured attack roll (no more attempts at trickery 
+are allowed).
+If the Player-­heroes achieve three successful Skill rolls, the 
+Troll is surprised when the first rays of the sun hit the clouds 
+above — suddenly terrified, the Stone-­Troll breaks away from 
+the fight, looking for shelter. If the Skill rolls achieved two or 
+more Success icons , the Troll is completely caught unawares 
+by the dawn, and is turned to stone on the spot!
+JACK, THE STONE-­TROLL
+ATTRIBUTE LEVEL
+8
+ENDURANCE
+34
+PARRY
++1
+ARMOUR
+3
+COMBAT PROFICIENCIES: Crush 2 (6/12)
+epilogue
+With Myrtle rescued, she is delivered by the wanderer and 
+the Player-­heroes back to her father Mort, who rejoices. It is 
+then that the cloaked Man reveals his identity. 
+The Lore­master can read or paraphrase the following text.
+Throwing back his hood, with one arm clutching his shoul-
+der, the cloaked wanderer reveals himself. He has long grey-­
+brown hair and bright, steely eyes. He smiles through the 
+pain of the wound he suffered at the claws of the Troll. “It 
+is not often that I find myself needing protection. Less often 
+that it should come in the form of you little, wondrous folk. 
+It would seem I still have much to learn.”
+“My name is Halbarad, and I am a Ranger, although 
+that title may not tell you much. Suffice it to know that 
+I, like yourselves, was searching for young Myrtle for two 
+James Smith (Order #47812382)
+
+Expert Treasure Hunters
+15
+reasons. First, for fear that she might find true danger. Sec-
+ond, because she took something I was meant to guard. I cer-
+tainly didn’t expect a burglar like Myrtle, and she fooled me.” 
+“What Myrtle took from Kings­worthy is indeed a rare 
+relic, a token of an ancient past, best forgotten. It was hid-
+den in plain sight, and has remained safe for a long time, 
+until today. But now I think I have found someone worthy 
+of its safekeeping. I think that if you have it, it may be in 
+better hands than mine.” He chuckles softly and his hard 
+eyes brighten a bit. “Now, if you would be so kind as to 
+see the Mudfoots home, I am certain they have a fine meal 
+waiting for them. I have wounds to tend to, but I hope 
+this will not be our last meeting.” He turns without wait-
+ing for a reply, and in a matter of seconds the shadows of 
+the heath swallow up the Ranger as if he were one of their 
+own, and he is gone.
+Once back at Oatbarton, Mort explains to his wife Marigold 
+what happened. She chastises him as only a wife worried sick 
+can, but prepares a grand feast for everyone as a thank you 
+for their efforts. After a fine meal and a long sleep, the Player-­
+heroes can begin their journey back to Bag End, with the club 
+of the Bullroarer hidden among their gear. 
+To their surprise, as they come up the lane of Bagshot Row, 
+they see a Dwarf in a red hood peeking into the window of 
+Bag End. He turns at their approach and casts off the hood, 
+revealing a keen smile and a long white beard.
+“Bilbo, you old rascal! You told me to drop by for tea any time 
+and here I am!” The Dwarf pauses with a grin and collects 
+himself before offering a polite smile. “Forgive my exuberance. 
+Balin, son of Fundin, at your service.” With a bow, he casts 
+a knowing smile at Bilbo, “What kind of trouble have you 
+gotten yourself into this time, my little burglar?”
+Balin, son of Fundin is now available to be chosen 
+as a Player-­hero for the next adventure. Having just 
+arrived for tea, he’s glad to help out his friend’s fel-
+low conspirators with whatever local trouble they get 
+themselves into.
+THE BULLROARER’S CLUB
+Bandobras “Bullroarer” Took used this massive club to 
+win the Battle of Greenfields and defeat the Goblin war-
+lord Golfimbul. Legend has it that one blow from the 
+great club knocked the Goblin chief’s head off and sent 
+it sailing into a far-­off rabbit hole — winning the battle 
+and inventing the game of golf at the same time! At the 
+end of the adventure, Bilbo will keep the club at Bag End 
+for study, and he will later donate it to the Mathom-­house 
+of Michel Delving, for everyone to admire. 
+Balin, son of Fundin
+James Smith (Order #47812382)
+
+ADVENTURES
+16
+most excellent fireworks
+The fireworks were by Gandalf: they were not only brought by him, but designed and made by him;  
+and the special effects, set pieces, and flights of rockets were let off by him.
+Once again, the affairs of the Shire and those of Gandalf the 
+Grey seem to be entwined. To better understand the nature 
+of the Grey Pilgrim’s wizardry — and for a bit of fun — Bilbo 
+asks the conspirators to find out what became of the last of 
+Gandalf’s fireworks, left over from the Old Took’s birthday 
+parties. The conspirators must travel to the Yale and discover 
+what became of them.
+This adventure can be played at any time after the 
+events of A Conspiracy Most Cracked, but before Invol-
+untary Postmen. If played in sequence, it is now the 
+summer of the year S.R. 1360.
+part one: unexpected 
+party favours
+The conspirators are gathered in Bag End for yet another 
+fine dinner on the lawn beside the Hill, when the horizon 
+to the south-­east suddenly lights up with a display of dazzling 
+colours! You can see thin tendrils of smoke curling up in 
+the darkening sky. Bilbo bolts upright and snaps his fingers. 
+“Those have to be Gandalf’s old fireworks! What are they 
+doing with them?” Before you can say so much as ‘pop and 
+hop,’ Master Baggins is already planning a new mission, to 
+set off and retrieve what he calls ‘the last of Gandalf’s party 
+favours.’ He informs you that years ago, Gandalf entrusted 
+the remainder of his fireworks to none other than Primrose 
+Boffin, now Bracegirdle, Lobelia’s own mother. Primrose, who 
+went to live in Hardbottle after her marriage, recently moved 
+back to the Yale, where she was born, setting off all sorts of 
+gossip. Now, judging by where those dazzling lights seemed 
+to come from, someone in the Yale must have tried to put 
+those fireworks to use again and may have set a fire going 
+with them. Bilbo continues: “Fireworks are not things to be 
+handled carelessly. And if they won’t be responsible then I 
+know a safe place for them!”
+Balin, who has turned a visit for tea into a stay of sev-
+eral days, offers to join the Company as he’d like to get to 
+know the Shire a bit more.
+A YALE YARN
+This adventure can dispense with the ­Hobbit walk required to 
+bring the Player-­heroes to their destination, by having them 
+start the game already in the Yale. Their walk had them fol-
+low the East Road all the way to Whitfurrows. 
+After asking for directions several times (or following 
+Lobelia’s, if she’s present), they reach the Boffin family estate 
+late in the morning, several miles south along the road that 
+leads from Whitfurrows to the Stock Road and the Woody 
+End. It’s a large farmstead, recently renovated, composed of a 
+stately house surrounded by farm buildings, in the middle of 
+wheat and barley fields and orchards. There are scorch marks 
+in a couple of the fields and a larger one closer to the house. 
+A rutted lane between low hedges leads to the front door. 
+James Smith (Order #47812382)
+
+Most Excellent Fireworks
+17
+Once they knock at the door, it flies open, and you see 
+the rather sour face of Primrose Bracegirdle greeting you. 
+“Aye, what do you want?”
+As it is immediately clear, Primrose is not terribly glad to 
+have visitors, not even her own daughter, especially after she’s 
+been wandering around the Shire in questionable Company. 
+When asked about the fireworks, she says that her son Bruno 
+came to visit last week and was fooling around with them. 
+After Bruno set a few off to entertain the local children, she 
+put a stop to all that nonsense and sent him back to Hardbot-
+tle to store the blasted things back at her husband’s house. If 
+they reveal that they have come so far specifically to retrieve 
+the fireworks, Primrose assures them that possession is the 
+greater part of the law, and if they want them, they’ll have to 
+buy them properly.
+WALKS AND WANDERINGS 
+IN WHITFURROWS
+The trip back to Whitfurrows is an easy walk, but by the time 
+the Player-­heroes arrive, it is late afternoon, and most of the 
+trading is done for the day. After a bit of looking and asking 
+around among the throng of traders, they find Bruno drink-
+ing in the company of a Dwarf mason. Bruno is about fifty, 
+and looks very much like a meaner and larger version of his 
+younger sister Lobelia.
+When asked about the fireworks, Bruno is initially ada-
+mant that he has no idea what they’re talking about. He is 
+suspicious of anything that has to do with ‘Mad Baggins’, and 
+if Lobelia is present, he reprimands her for getting involved 
+in such ‘adventurous nonsense’.
+Bruno can be coerced into revealing the truth with a 
+successful Skill roll (AWE, PERSUADE, or RIDDLE are 
+all appropriate). 
+On a success, he tells the Player-­heroes that he passed the fire-
+works off to one of the ­Hobbits working for his father Blanco 
+— one Otho Sackville-­Baggins, who agreed to take them back 
+to Hardbottle, after a stop in Scary for a pint. If the roll is 
+a failure, Bruno just says that he sent the fireworks home.
+STORMS IN SCARY
+Setting off north out of Whitfurrows and Budgeford, the 
+Player-­heroes begin their journey towards Scary late in the 
+evening. If they want to catch up with Otho, they must press 
+on for at least a few hours in the dark. Before long, the sky 
+clouds over, and a heavy rain begins to fall. 
+Slogging through the rain, even in a place as gentle 
+as the Shire, is no comfortable task, and each of the 
+Player-­heroes will need to make a TRAVEL roll to stave 
+off the weariness of a wet and cheerless evening, with 
+failure resulting in gaining 2 Fatigue points.
+With their slowed pace on the muddy road and a brief stop 
+in an abandoned building to wait for the rain to cease, the 
+conspirators arrive in Scary about one hour after dawn. 
+Scary is an unwelcoming village by ­Hobbit standards, nes-
+tled as it is on the south side of the Hills of Scary. It’s popu-
+lated by hard-­working, no-­nonsense ­Hobbits living in homes 
+made of grey stone. Most folk are terse and a bit unkind, but 
+if the Player-­heroes ask around about other travellers from 
+the south, they are told that the last visitor seen coming into 
+town took a late bed at a building owned by some mining 
+officials from Dwaling.
+The building is a small, single-­story house, with a couple 
+of small bedrooms and a tiny common room containing three 
+tables. When they get there, the conspirators find a ­Hobbit 
+from Dwaling, a mining accountant by the name of Filibert 
+Banks, busy scribbling in a large tome. 
+If questioned, Filibert seems to take for granted that the 
+­Hobbits are on some business errand, especially if he hears 
+Lobelia’s family name (the Bracegirdles have a flourishing 
+local business in construction), and thus proves to be quite 
+cooperative. 
+James Smith (Order #47812382)
+
+ADVENTURES
+18
+Useful information can be extracted from Filibert with 
+3 successful Skill rolls, using any ability the conspira-
+tors and the Lore­master deem relevant. 
+The Player-­heroes can play the conversation freely, but any 
+Player-­hero who fails a roll cannot make any more rolls to 
+inquire further. 
+	
+♦Upon a first success, Filibert reveals that he and Otho 
+had a long ‘business’ conversation while in their cups. 
+Filibert told his roommate for the night that based on 
+his accounting, there was a tunnel in the quarry that 
+proved to be very fruitful, but that no one, not even 
+Dwarves, had been able to penetrate it deeply, for the 
+rock was too hard. 
+	
+♦On a second success, Filibert regales the Player-­heroes 
+with ghoulish tales about ‘the lost miner’ haunting 
+that specific tunnel, stories of passages abandoned 
+after flooding, and rumours of ghostly voices echoing 
+in the empty chambers. 
+	
+♦A third and final success has Filibert relating how 
+Otho, inebriated with Filibert’s story of an untapped 
+‘treasure mine’, started blathering about how soon 
+everyone in the Shire was going to be speaking to him 
+with proper respect, while he kept patting the large 
+sack he brought with him.
+The final revelation from Filibert about Otho is that he stum-
+bled off more than a bit tipsy a few hours before dawn, after 
+having asked Filibert for directions to reach ‘his treasure 
+mine’. He left with a lantern, a tinderbox, a coil of rope, 
+and his large sack. 
+part two: quest 
+in the quarry
+Having been mined by ­Hobbits since the days of Marcho and 
+Blanco, the Hills of Scary are riddled with holes, tunnels, and 
+all sorts of excavations. During the day, the area is bustling, 
+with workers going in and out of their mines, or tending to 
+the stone pulled from the quarries. Almost as grumpy as busy 
+Dwarves, they have little news to offer to nosy strangers — no 
+one seems to have seen Otho entering or leaving. 
+If the Player-­heroes try to reach the ‘treasure mine’ openly, 
+possibly following directions provided by Filibert, they soon 
+discover that it’s impossible to reach — as soon as they get 
+near, they are stopped by mining officials and sent back to 
+the village. After a brief investigation, it should be clear to 
+the Player-­heroes that slipping in during the day is impossible. 
+Coming back after sunset seems to be the only way. 
+You wait for the sun to set. As you follow the rutted track that 
+Filibert showed you, you get closer and closer to the dark that 
+lies at the feet of the Hills of Scary. Here, the night air makes 
+you shiver, as you carefully try not to stumble on the many 
+broken rocks littering the path. In time, your eyes adjust and 
+the outline of the hilltops appears, contrasting against the 
+night sky. On the side of the hills, you make out the many 
+tunnels gaping like bleak mouths leading into a seemingly 
+impenetrable blackness. 
+It’s a scary prospect to go underground at this hour of 
+the night, but you must discover what happened to Otho 
+Sackville-­Baggins before it’s too late. 
+Exploring the mines at night with only the light of 
+a few lanterns is a daunting task. As a consequence, 
+once the conspirators enter the dark beneath the hills, 
+they must all pass a VALOUR roll to avoid losing 1 
+point of Hope. 
+A SOUGHT-­AFTER SACKVILLE
+To find where the foolish ­Hobbit has gone, the Player-­heroes 
+must explore the branching tunnels of the ‘treasure mine’. 
+The conspirators must choose one Player-­hero as their 
+guide in the tunnels — the guide can make a roll of 
+EXPLORE once every hour. 
+To determine whether they find Otho, the Lore­master rolls a 
+Success Die once for every successful EXPLORE Skill roll, add-
+ing 1 to the result for each Success icon  rolled by the Player-­
+hero. Then, the Lore­master checks the roll result against the 
+following entries. 
+1.	 FORGOTTEN SUPPLIES. You find a crude map of the 
+mine left behind by some workers. Add 1 to the next 
+roll.
+2.	 A NARROW SQUEEZE. Maybe you shouldn’t have had 
+that extra morsel at breakfast! Squeezing through a 
+particularly tight passage has led to scraped knees and 
+torn knuckles. The guide loses 1 Endurance.
+3.	 AN ILL WIND. A chill wind seems to sweep up the 
+passage from nowhere, extinguishing your lanterns. 
+Relighting them takes some time, but the long dark 
+and flickering lights are disturbing and will require 
+a VALOUR roll from everyone before the lanterns are 
+relit (lose 1 Hope on a failure). 
+4.	 SORROWFUL SONGS BENEATH THE STONE. An indeci-
+pherable and ominous lament echoes across the stone 
+and fades to nothing. 
+James Smith (Order #47812382)
+
+Most Excellent Fireworks
+19
+5.	 A HORRIBLE END. A broken pickaxe, a torn piece of 
+cloth, and a smear of blood on the wall hint that some 
+poor ­Hobbit miner met a terrible end.
+6.	 You have found the lost Otho Sackville-­Baggins! Go to 
+Mad as an Orc, below.
+MAD AS AN ORC
+A flickering flame casts jagged shadows at the end of a pas-
+sage that ends in a pile of tumbled rocks. The Player-­heroes 
+hear a mad cry echoing against the rock and into the dark-
+ness. As they round the corner, they see a lantern set upon a 
+stone, casting long shadows over a terrible sight: a terrified 
+­Hobbit stands in front of a massive pile of fireworks piled up 
+at the blocked end of a tunnel, feebly brandishing a shovel 
+at what appears to be a grey Orc. Otho is screaming madly at 
+the creature: “It’s my treasure, ye monster! Mine! Mine! I’ll blow 
+it to rubble before I let ye have it!”
+On your arrival, the ­Hobbit turns and screeches in 
+renewed fright. He stiffens and stammers, failing to hide his 
+abject panic. If the players don’t act quickly, Otho will likely 
+bury them all in the mine. 
+The Orc is a very decrepit Orc veteran, who was lost long 
+ago, and took refuge deep in the mines and in the natural 
+caves under the Hills of Scary. Since then, he has been hiding, 
+trying to drive the ­Hobbits from his lair whenever they would 
+come too close to discovering his presence. The players will 
+have to take up arms to stop him from attacking Otho, an 
+act that will most likely end in a quite spectacular explosion 
+and the destruction of the mine. 
+At the arrival of the Player-­heroes, the Orc turns his atten-
+tion to the newly arrived threat and attacks. He will fight until 
+Wounded or reduced to half or less of his Endurance before 
+fleeing into the dark passages of the mine.
+ORC VETERAN
+ATTRIBUTE LEVEL
+4
+ENDURANCE
+16
+PARRY
++2
+ARMOUR
+3
+COMBAT PROFICIENCIES: Jagged spear 3 (3/14)
+epilogue
+If Otho is saved, the Player-­heroes receive little thanks from 
+the wayward ­Hobbit. Despite having his life spared by their 
+timely arrival, Otho fully intends to stake his claim on this 
+part of the mine. So, he proposes the following deal: if the 
+conspirators agree to serve as witnesses to the signing of con-
+tracts giving Otho exclusive mining rights to the tunnel (seven 
+signatures in red ink, all right and proper), he will give them 
+half of the Wizard’s excellent fireworks. If they agree, Otho 
+informs them that he’ll pass the contracts on for Lobelia to 
+sign, and they can take half the fireworks with them to Bag 
+End — he’ll personally repay the Bracegirdles for the fire-
+works out of his own pocket.
+As for the Orc veteran, the Player-­heroes can inform 
+the mining officials of his presence. They will then inves-
+tigate the mine and eventually discover a deep passage 
+that was previously undiscovered, littered with bones of 
+small animals and remnants of an encampment, but 
+no signs of Orcs... 
+Upon their return to Bag End, Bilbo stores the 
+remaining fireworks in one of his cellars, under lock 
+and key.
+James Smith (Order #47812382)
+
+ADVENTURES
+20
+involuntary postmen
+… the offices of Postmaster and First Shirriff were attached to the mayoralty, 
+so that he managed both the Messenger Service and the Watch.
+No trouble goes unnoticed in the Shire, and the Bounders 
+have finally decided to take action against the conspirators 
+and their ongoing mischief. By order of the Shirriffs, Bilbo 
+Baggins’ ­Hobbit collaborators have been sentenced to clean-
+ing the cold storage and wine cellar underneath the Town 
+Hole at Michel Delving! But the sympathies of an overworked 
+member of the Quick Post and the promise to deliver a letter 
+clear across the Shire to Brandy Hall could earn them early 
+release, and a new adventure to boot!
+This adventure can be played at any time after the 
+events of A Conspiracy Most Cracked, immediately pre-
+ceding To Soothe a Savage Beast. If played in sequence, 
+it is now late summer, in the year S.R. 1360.
+part one: captive 
+conspirators
+This adventure opens with the Player-­heroes (not including 
+Bilbo or Balin) having already been rounded up by several 
+local Bounders after news of their troublesome misadven-
+tures have turned the Shire into a buzz of concern and gos-
+sip. As time passed while they were wandering about, several 
+­Hobbits for whom they’ve caused trouble have reported on 
+their misdeeds. This can include custodian Malva Slowfoot, 
+Bounder Ada Burrows, Primrose and Bruno Bracegirdle, 
+and any other busybodies they have disturbed during their 
+adventures. Their troublesome ways have finally caught up 
+with them!
+This is intolerable! You always wanted to visit the Town Hole 
+in Michel Delving, but not like this. It appears the conspira-
+tors have finally met one trouble they could not escape. After 
+being confronted by a group of Bounders and charged with 
+claims of disturbing the peace and on-­going rowdiness, the lot 
+of you have been detained in the storage tunnels beneath the 
+Town Hole until Mayor Pott can decide what to do with you.
+While there are worse things than being locked in a stor-
+age cellar beneath the Town Hole, it is an uncomfortable 
+place. A heavy wooden door, barred from the other side, blocks 
+you from freedom, and other than the occasional Bounder 
+coming by, no one has so much as brought you a seed cake to 
+munch on for hours! When Bilbo finds out about this, they 
+will regret their actions… he will find out, right?
+OUT OF THE CELLAR
+The incarcerated conspirators take a few moments to investi-
+gate the storage cellar: they see a number of sealed beer bar-
+rels and several cuts of salted meat, inedible without prepa-
+ration, and several large loaves of crusty bread and wheels of 
+hard cheese (the Loremaster should note if any Player-heroes 
+take some of the foodstuffs as it may become relevant later 
+in the adventure). 
+The ground here is packed dirt, and the walls are the 
+same, save for a few support beams. A single, weak lantern is 
+set on one of the barrels for light (using it to start a fire in 
+the middle of Michel Delving is probably not the best idea). 
+Their usual possessions and any weapons have naturally been 
+taken from them by the Bounders, and have been stored in 
+James Smith (Order #47812382)
+
+Involuntary Postmen
+21
+the corridor outside the cellar door (the gear can be easily 
+retrieved if they find a way to get out).
+The conspirators remain here without news from out-
+side long enough to make them despair about their fate. Just 
+when they are getting too restless, a soft knock is heard at 
+the door and a reluctant voice hisses out. Awkwardly, the 
+voice introduces itself as Odo Proudfoot. They recognize the 
+name as belonging to someone working for the Quick Post 
+in Michel Delving. Odo asks if he can come in, which will 
+likely seem strange to the company, seeing as the door han-
+dle is on his side.
+If he receives a positive response, he and Mayor Pott 
+step within the chamber. He leaves the door open, allowing 
+the characters to see their gear stacked up neatly against 
+the wall. Odo explains that the Quick Post is short-handed 
+and he has a letter that needs delivering to Bamfurlong, 
+in the Marish. 
+He has no one to send and got the impression from the 
+tall, hooded figure that accosted him outside town with the 
+letter that the message was urgent. Furthermore, there’s a lot 
+of traffic on the main road – Dwarves mostly, heading west or 
+east as the case may be, trying to get home before the year 
+grows too long. 
+The Mayor speaks up, saying that the conspirators owe 
+community service for their transgressions and that they have 
+been volunteered to deliver the letter, ‘unless you’d rather 
+stay here.’
+If they accept, then Odo hands them the sealed letter, 
+instructing them to take it to Bamfurlong, staying off the East 
+Road and taking the Stock Road instead, thus cutting across 
+the Green Hills and going through the Woody End. 
+Before he lets them go, Odo adds that he promised the 
+hooded figure that the letter would stay sealed — only to be 
+opened by Farmer Maggot, to whom it is addressed.
+LEAVING MICHEL DELVING
+Once the characters gather up the gear, Mayor Pott leads 
+them back upstairs and out through the Mathom-house. Play-
+er-heroes who mention that they are scouting for anything of 
+use notice that a series of strange, two-wheeled contraptions 
+made of wood and metal have been lined up against the wall 
+of the Mathom-house — certainly some newly-delivered acqui-
+sitions of the museum. Malva Slowfoot has labeled them with 
+a tag, identifying each one as a ‘velocipede’. 
+Whether they’re a strange creation by some eccentric 
+Shire craftsman or a Dwarven smith, these velocipedes look 
+like vehicles that can be ridden at some speed! Mayor Pott 
+harrumphs if the player-heroes ask to use the velocipedes; he 
+reminds them that they are doing community service and he 
+expects them to suffer, at least a little bit.
+If the Player-­heroes ‘borrow’ the velocipedes to leave 
+Michel Delving in a hurry, they must pass a roll of 
+ATHLETICS to master the strange contraptions without 
+anyone noticing their clumsy attempt. A failure indi-
+cates that some local takes notice of the Player-­heroes’ 
+suspicious activities, and the theft of the velocipedes 
+is added to the conspirators list of misdeeds!
+If the Player-heroes leave Michel Delving riding the veloci-
+pedes, whenever they must make a roll of TRAVEL they gain (1d).
+THE LETTER TO BAMFURLONG
+­Hobbits have a great respect for propriety and 
+privacy, and that includes matters of the Quick 
+Post. The letter is sealed by wax, but has no sym-
+bol set into the seal. Player-­heroes would know 
+that opening the letter would be a most improper 
+invasion of privacy, and the misdeed would cost 
+them 1 point of Hope
+Odo Proudfoot
+James Smith (Order #47812382)
+
+ADVENTURES
+22
+part two: round and round
+Having escaped Michel Delving, the Player-­heroes now begin 
+their journey east towards the Marish and Bamfurlong. Nor-
+mally, such a trip should take about four or five days to com-
+plete, and require the rules for ­Hobbit Walks described on 
+page 10 of The Shire. But while the Shire is a peaceful land free 
+of many of the troubles that plague other regions, travelling 
+across its length is not without its own challenges.
+From your first hours on the road, you realise that what Odo 
+told you seems right — more Bounders than usual are out 
+making their rounds. So, you have no other choice than to 
+stay off the roads. This means riding along well-­trodden 
+country paths and tracks, heading east towards Whitwell, 
+and Tookland beyond. 
+But what could be little more than an extended walking 
+party soon proves troublesome... You have set out on your post-
+man duties across the Shire without provisions, save for a few 
+bits of old and stale bread and cheese from beneath the Town 
+Hole of Michel Delving, and this is a problem of capital import! 
+The first day of travel brings the Player-­heroes to the outskirts 
+of Tookbank — they may consider the possibility of sneaking 
+into town and purloining something to eat — but that is a 
+risky business. Alternatively, they can search for wild fruits 
+and berries growing in the open land, or even attempt to 
+‘borrow’ carrots or other choice vegetables from one of the 
+many farms of Tookland. Hunting small game is right out, 
+given that the tiny creatures found in the region are not likely 
+to make more than a mouthful even if they could be snared.
+On their second day of travel, dawn comes bright and 
+clear, with all indications that it will be a perfectly fine day 
+for walking. However, as midday draws near, the sky turns 
+grey, and heavy clouds roll in. By the time lunch has passed, 
+a heavy rainstorm has released its fury, and the Player-­heroes 
+find themselves trudging through muddy terrain as they head 
+towards the Green Hill Country. 
+Each Player-­hero gains 2 additional points of Fatigue 
+as the weight of hard travel begins to press down upon 
+them, body and soul (a roll of TRAVEL can reduce the 
+amount of points gained, as usual).
+The rain subsides at sunset, and soon the night sky clears. 
+Plodding in the dark on hilly terrain is not a wise idea, and 
+while the Player-­heroes might press on into the Woody End 
+that evening, it is probably best that they bed down for the 
+night. Just as they are about to sleep for the evening, a pair 
+of red squirrels wander curiously into their camp, and try to 
+steal some food from the travellers. If shooed away rudely, 
+they flee into the woods, but if treated kindly or even offered 
+a bit of food by the ­Hobbits, they take a few bites off whatever 
+they are offered, chitter excitedly, and flee into the woods.
+As the Player-­heroes enter the Woody End itself on their 
+third day of travelling, the Lore­master must consider how the 
+Player-­heroes interacted with the beasts they have encoun-
+tered in their adventures so far. This includes Firework the 
+dog from A Conspiracy Most Cracked, Gertrude the mule and 
+the owl in Waymeet, and the curious squirrel couple encoun-
+tered the previous evening. Word of their actions has spread 
+among these creatures across the Shire, and now their rep-
+utation precedes them. 
+If in the majority of cases the animals were treated 
+kindly and shown compassion, then the Player-­heroes 
+find their journey in the forest light and easy, discover-
+ing convenient berry bushes along the road, allowing 
+them to eat, and finding the finch songs reaching into 
+their heart restoring 1 point of Hope to each of them. 
+FINDING FOOD TO GO
+The Lore­master can resolve any foraging action 
+attempted by the Player-­heroes as follows (each 
+player has one Skill roll attempt each day of travel):
+	
+♦
+Player-­heroes attempting to sneak into a vil-
+lage to steal food must make a STEALTH roll, 
+but they lose 1 Hope when they do so!
+	
+♦Those searching the wilderness for wild fruit 
+can make an EXPLORE roll. 
+	
+♦Anyone looking for a vegetable field to pluck a 
+cabbage or two from can make a SCAN roll, but 
+they lose (1d) as they must cover large areas. 
+Success means they have found enough food for 
+themselves for one day. Each Success icon  yields 
+enough food to feed themselves for an additional 
+day — or to feed themselves and another ­Hobbit.
+Any Player-­hero who goes to bed each 
+day with an empty belly gains 1 point of 
+Fatigue, in addition to whatever is gained 
+for travelling, and must make a WISDOM 
+roll to avoid losing 1 Hope as they suf-
+fer the incomprehensible fate of going to 
+bed with no supper.
+James Smith (Order #47812382)
+
+Involuntary Postmen
+23
+If the animals were treated poorly, the forest is oppres-
+sive: the sounds of the beasts and birds have a dour 
+and unwelcome note to them, and each day of travel 
+in the Woody End requires a VALOUR roll to avoid 
+losing 1 Hope.
+part three: enchantment 
+in the woody end
+As the Player-­heroes reach the eastern edge of the Woody 
+End and they hear the babbling waters of the Stock-­brook, a 
+new enchantment reveals itself. 
+The stars burn bright and free tonight, in spite of your wea-
+riness and the hunger you have faced along your journey. 
+A lightness enters your heart as you rest upon the banks of 
+the Stock-­brook. Then, as if the starlight were given form 
+and voice, you see a being from legend step out of the soft 
+embrace of night to shine upon you. A voice like music says 
+“Elen síla lúmenn’ omentielvo.”
+As if given form by that song, you see an Elf, clad in blue 
+raiment with hair as fair as gold. He smiles at you and your 
+companions, “Whether it be a merry chance or some greater 
+will that has brought us together, I am glad for it. I am Gal-
+dor of the Havens, and I have long been curious about the 
+mischievous ­Hobbits that have been going about causing all 
+manner of stories to be spun by birds and beasts across the 
+Shire. Why, I spoke only a few days ago to Badger-­brock of 
+the Withywindle, and he told me of your company, each by 
+name, as he had heard it from a finch, who heard it from a 
+fox. I suspect that by now, even Iarwain in the Old Forest 
+has heard of your merry mishaps. But I am forgetting myself, 
+adopting rustic ways for these rustic realms. May I trade 
+some simple Elvish travelling fare in exchange for sharing 
+your Company and your camp this evening?”	
+If the Player-­heroes accept Galdor’s Company, he does indeed 
+provide them with loaves of fair white bread and a light, 
+golden beverage. 
+The Elvish provisions restore both heart and spirit, 
+restoring each Player-­hero to their full Endurance, 
+cancelling all accumulated Fatigue, and restoring 1 
+point of Hope each, as they fill bellies and lift spirits. 
+Galdor of the Havens
+Galdor is a kind but curious guest, and subtly questions the 
+Player-­heroes. This attempt goes unnoticed unless a Player-­
+hero succeeds in an INSIGHT roll. If they fail, he draws the 
+truth of their adventures from them — but he offers laugh-
+ter, a light heart, and a fair song in return for this informa-
+tion. He tells them to sleep peacefully tonight, for they have 
+nothing to fear.  
+When the ­Hobbits wake in the morning, they find fresh 
+fruit and nuts to serve as breakfast, and Galdor is already 
+awake. He tells them that he has an errand to attend to, and 
+must now depart. He offers them blessings and cautions 
+regarding further adventures. Moments later, he vanishes 
+into the forest of the Woody End.
+James Smith (Order #47812382)
+
+ADVENTURES
+24
+epilogue
+Later that same day, the conspirators finally cross the Stock-­
+brook at a spot where it meanders shallowly and can be 
+forded. After having asked some fishermen for directions, 
+the Player-­heroes arrive that afternoon at Bamfurlong in 
+the Marish.
+Bamfurlong is a long brick farmhouse with a thatched 
+roof, surrounded by great fields of vegetables in their full 
+bloom of the season which run up to a high wall with a gate 
+that marks the entrance upon the lane. It is located approx-
+imately halfway between Stock and Rushey.
+As the Player-­heroes approach, they see a young but 
+broad ­Hobbit in his tweens working the fields, and stop-
+ping to watch them closely as he leans upon a shovel. Upon 
+spotting the Player-­heroes, he shoulders the shovel, saun-
+ters towards them, and tersely asks them their business. He 
+regards them cautiously, one by one. He offers them noth-
+ing but a stern look and his name, Farmer Maggot, dismiss-
+ing them out of hand unless they mention that they carry 
+a letter for him. He asks them to produce the letter, which 
+he snatches from them and tears open on the spot. After 
+reading a few lines, he lets out a deep laugh, and seems to 
+relax into an amiable ­Hobbit. 
+“I was told you were coming, but I wasn’t sure I would have 
+actually seen you in the flesh. It’s quite a long road from 
+Michel Delving! Please, please, follow me. You must be hun-
+gry, and thirsty, and quite weary by the look of you.”
+Farmer Maggot invites the conspirators to follow him to his 
+home, where he leads them into his kitchen. There, they see 
+a fine table has been laid, and none other than Bilbo Baggins 
+himself sits at it, eating a bright-­coloured apple! 
+Bilbo smiles impishly at Maggot, and winks at the Player-­
+heroes. 
+“Oh, I see you got my letter, good Mister Maggot! Now that 
+we’re all here, we’ll get to the business at hand!”
+Farmer Maggot
+James Smith (Order #47812382)
+
+To Soothe a Savage Beast
+25
+to soothe a savage beast
+There was victory and defeat; and towers fell,  
+fortresses were burned, and flames went up into the sky.
+One final favour, and Bilbo will leave his beloved conspirators 
+in peace. He joins them for a visit with young Farmer Maggot, 
+freshly of Bamfurlong, as he is a shrewd farmer with much 
+insight into the misunderstood ways of Bucklanders. But Mag-
+got has his own troubles with a terrible beast from over the 
+High Hay, and before long, the conspirators find themselves 
+in the heart of the Old Forest after dark and face to face with 
+the true wonder and danger that awaits when simple ­Hobbits 
+move beyond the borders of the Shire.
+This adventure should be played as the last one taken 
+from this volume. If played in sequence, summer is 
+now waning, in the year S.R. 1360.
+Having arrived before the others at Bamfurlong, Bilbo 
+returns as a playable Player-­hero available to the play-
+ers. If they need to swap out an existing character it is 
+recommended that Lobelia be the one to leave the con-
+spirators — clearly having had more than enough of 
+this nonsense, and quite infuriated to have anything to 
+do with Bucklanders and any business beyond the Shire 
+proper, she returns to her mother’s home in the Yale.
+part one: buckland bound
+The adventure opens with the Player-­heroes awakening once 
+again in comfortable beds inside the farmhouse of Bamfur-
+long to the scent of eggs and mushrooms cooking for a late 
+breakfast. The last few days have been a welcome comfort 
+after their long journey across the Shire. 
+ The Lore­master should restore each character to their 
+full Endurance, as they have had a few days to rest. 
+Bilbo and Maggot both dismiss any ‘business talk’ until after 
+the table has been cleared, but soon after the crockery has 
+been cleaned and pipes have been lit, Maggot’s demeanour 
+turns grim.
+The Lore­master can read or paraphrase the following text.
+Sitting upon a long bench under the eaves of Bamfurlong, 
+Farmer Maggot takes a long draw from his pipe and gazes 
+out to a small ruined building on the far side of his wide 
+farmlands. “Chickens,” he says suddenly as he blows out a 
+long line of blue-­grey smoke. “It is because of my chickens 
+that I sent my letter, Master Baggins.”
+Any hint of jest fades away as he leans in to you and 
+your friends. “And to be honest, I’m glad you have not come 
+alone. When I saw that thing that night, blood in its teeth 
+and fire in its eyes, I knew it was something beyond the 
+ken of myself or any other folk in the Eastfarthing. It was 
+a beast, I tell you, and not some hungry wolf that came up 
+from Dunland starving. This was a black thing, as if its fur 
+had been burnt like kindling, with nothing natural about 
+it, and it set chills down my spine — no easy task, mind 
+you. But when I heard it growl at me, we locked eyes and I 
+saw naught but a lust for death in its gaze. It meant to kill 
+more than my chickens in their coop that night. I grabbed a 
+lantern in one hand you see, and my chopping axe. If it was 
+going to take me, I wasn’t going down without a fight. Before 
+I knew what happened, it was on me, crossing the field in a 
+bound and pinning me to the soil, snarling and slavering.” 
+James Smith (Order #47812382)
+
+ADVENTURES
+26
+Maggot’s eyes glaze over in memory and you see him 
+tremble at the recollection. “In a fit, I swung my lantern up 
+and it shattered, pouring oil upon its muzzle. It yelped and 
+screamed as the fire blazed, and it fled into the dark. The 
+last things I saw before it disappeared towards the Brandy­
+wine were those horrible, fiery eyes.”
+He sets his pipe on the bench beside him. “It's still out 
+there. I swear I’ve seen it beyond the edges of Bamfurlong 
+on more than one night since then, those eyes burning into 
+me from the dark. And if the stirrings from Buckland are 
+any hint, it is causing no end of trouble there too. Master 
+Bilbo, sir, I was hoping that you and your friends here 
+might help me and the Buckland folk put a stop to that 
+foul thing’s hunting before it gets a taste for something 
+more than chickens.”
+Maggot has little to offer in reward for their aid, but will give 
+the conspirators a bed at Bamfurlong should ever they need it 
+in days to come, and send them off with a basket of his mush-
+rooms, which can serve as fine provender as they search for 
+the ‘Burnt Beast’, as he calls it, with a promise of more any 
+time they wish after the matter is settled. 
+Finally, Maggot adds that he only ever saw the beast 
+at night, and he believes it has somehow crossed over to 
+Buckland and is troubling the Brandybucks now, based on 
+news he’s heard from Buckle­bury. They might want to begin 
+their search for the creature by crossing the Brandy­wine 
+at Buckle­bury Ferry, and should probably depart this same 
+evening.
+UP THE CAUSEWAY TO BUCKLE­BURY FERRY
+The trip up the Causeway to reach Buckle­bury Ferry is an 
+easy one, but the evening air feels strangely still. No ­Hobbits 
+are seen relaxing out of doors on their farms in the Marish, 
+and no children are found catching fireflies. 
+One hour later, about halfway to the Ferry, the Player-­
+heroes feel a growing sense of dread creeping over them, as 
+if a rabbit were sensing a nearby predator. It’s a disheartening 
+feeling, seeping into their very bones. 
+As they continue on, any Player-­hero who states that 
+they are looking around for a source of the dread can 
+attempt an AWARENESS roll. Failure means they are 
+unable to spot something specific that is causing their 
+unease, but those who are successful see a pair of red 
+eyes here and there. Once behind a fence, another 
+time obscured by a row of hedges, and again slipping 
+away behind a small house. 
+Upon finally reaching the winding road that turns east off 
+the Causeway, they begin walking down the path towards 
+Buckle­bury Ferry. Indeed, they can see it for themselves in 
+the distance, illuminated by starlight reflected in the Brandy­
+wine River.
+The Lore­master can read or paraphrase the following text.
+At last this uneasy night stroll reaches its destination. You 
+see as you turn off the Causeway, further down the lane, the 
+square floating platform that is the Buckle­bury Ferry. With 
+no ferryman tending it at night, you will have to cross on 
+your own, but the water is calm, and the stars are bright. 
+A sigh of released tension is prematurely interrupted when 
+you see a pair of red eyes come up from the ditch along the 
+western side of the Causeway. 
+James Smith (Order #47812382)
+
+To Soothe a Savage Beast
+27
+It may have once been a dog or wolf, but its fur is burnt 
+and stiff, the colour of cold ashes. Fiery eyes gleam in the 
+night as it prowls towards you, never flinching. Its predatory 
+confidence grows with each step. Never once does it make a 
+sound, not even its footfalls. Nearly as tall as a ­Hobbit at 
+the shoulder, its silent snarl reveals white fangs stained pink, 
+as it breaks into a charge towards you!
+This is a true battle. The Player-­heroes have little time to pre-
+pare for it, and indeed it might be wiser for them to consider 
+the option of escaping, for example using the Ferry. 
+Racing down the road and leaping onto the ferry 
+requires an ATHLETICS roll, and the choice of whether 
+to stand and fight or flee must be made quickly. 
+The Lore­master should press the players, and force them 
+to make their choice swiftly. Those who fail their roll to 
+flee fall behind and become a prime target for the terrible 
+black beast.
+Player-­heroes who muster their courage and decide 
+to stand and fight in hopes of delaying the creature 
+or protecting their friends can manage one Opening 
+Volley before the beast is upon them. If the creature 
+takes 10 or more points of damage, it turns and flees, 
+leaping over the far side of the Causeway and disap-
+pearing into the night.
+Once the characters have begun their crossing, keen eyes 
+gazing back upon the western bank of the Brandy­wine River 
+and succeeding in an AWARENESS roll to notice a pair of red 
+eyes watching them from the darkness, before the beast darts 
+to the north along the river bank.
+BURNT BEAST
+ATTRIBUTE LEVEL
+5
+ENDURANCE
+20
+PARRY
++2
+ARMOUR
+3
+COMBAT PROFICIENCIES: Fangs 4 (5/14)
+FELL ABILITIES: Great Leap. The Burnt Beast can attack any 
+Player-­hero, in any combat stance. 
+Denizen of the Dark. All attack rolls made by the Burnt 
+Beast are Favoured while in darkness.
+part two: 
+buckland troubles
+After crossing the Brandy­wine, the Player-­heroes enter Buck-
+land and head towards Brandy Hall in the late hours of the 
+night. Right after leaving the ferry, they are approached by 
+a Bucklander watchman carrying a lantern, with his other 
+hand resting on the pommel of a sheathed short sword. He is 
+terse with the Player-­heroes, telling them that they shouldn’t 
+be using the ferry at night, and that any strangers are to be 
+escorted to Brandy Hall for their own safety. He offers to 
+guide them the rest of the way. If they refuse, he insists, say-
+ing it’s the Master of Buckland’s orders.
+While walking to Brandy Hall, any Player-­heroes that 
+ask the guard what is causing the extra security mea-
+sures must make a COURTESY roll to get him to open 
+up — though no roll is necessary if Rory or ­Primula 
+Brandybuck are among the Player-­heroes present. If 
+successful, he introduces himself as Braddoc, and 
+reveals that there are rumours of a savage creature 
+threatening the locals. If they roll one or more  icons, 
+he tells them some kind of wild dog matching the 
+description of the beast was seen prowling around 
+Crickhollow, terrorizing the area.
+Upon arriving at Brandy Hall, the Player-­heroes are given 
+a chance to rest and recount their troubles. The Master of 
+Buckland himself, Gorbadoc Brandybuck, comes to hear their 
+tale, for it concerns him greatly, as Rory and Primula are his 
+children and Drogo is to be his son by marriage. 
+Lore­masters can read or paraphrase the following text 
+to open the scene.
+Braddoc the watchman leads you up the road and to the 
+main entrance of the grand ­Hobbit-­hole that is Brandy Hall. 
+Much to your surprise, given the time of night, you see none 
+other than the Master of Buckland, Gorbadoc Brandybuck 
+himself, pacing on the front walk. Pipe clenched in his teeth 
+and leaning on a heavy wooden cudgel, he looks up at the 
+light of Braddoc’s lantern and smiles. “Glad to see you, my 
+lads and lasses.”
+Trouble is visible on Gorbadoc’s face, but he waves it away 
+after offering Braddoc a quick thank you and asking the 
+group if they’d like to come in for some late-­night vittles. 
+Once they’ve all sat down at the table, Gorbadoc assures 
+everyone that they’ll have proper lodging for the night. It’s 
+only then that he brings up the subject of the creature, ask-
+ing anyone injured in their previous encounter with the 
+beast where they got their wounds. He tells them that the 
+James Smith (Order #47812382)
+
+ADVENTURES
+28
+beast has been prowling about Buckland as well, and it trou-
+bles him to hear it's somehow crossed the Brandy­wine — 
+such a thing makes no sense to him, as the creature was 
+only spotted last night, and he finds it hard to believe that 
+the beast swam the length of the Brandy­wine and then back 
+again to trouble Farmer Maggot. 
+The beast, Gorbadoc tells them, has been taking livestock 
+from Newbury, and just last night Rollo Boffin sounded the 
+alarm, claiming he saw the beast on the edge of his property 
+at Crickhollow. He fears it's only a matter of time before the 
+creature hurts someone. 
+Before going to bed, Gorbadoc adds that even as Master 
+of Buckland, he’s got no right to tell others how to live, but 
+if they’re going to stick their nose into this matter they’d 
+best be careful.
+CRISIS AT CRICKHOLLOW
+An hour before dawn Saradas Brandybuck (brother of Rory 
+and Primula) wakes the Player-­heroes, and tells them that 
+there’s been another attack. Rollo Boffin came running from 
+Crickhollow all the way to Brandy Hall, screaming that he’d 
+seen the beast again, and that this time the thing had been 
+snarling at his very window. Saradas tells the Player-­heroes 
+that Gorbadoc is asleep, and he didn’t want to wake the old 
+Master, so he came and got them instead.
+Saradas leads them to a parlour in Brandy Hall where 
+the newly arrived Rollo is sitting with shaking hands, nurs-
+ing a cup of tea. Fearfully, and with stumbling words, Rollo 
+describes the beast he saw, with fur burnt black and red 
+fiery eyes, stalking back and forth near the edge of his 
+property. He panicked and fled, running as fast as he could 
+until he reached Brandy Hall. He begs the conspirators 
+to help him.
+When Rollo’s story ends, the players turn to see Gorbadoc 
+who has been standing in the doorway listening quietly. With 
+a reluctant look upon his face, he nods, saying Rollo is right. 
+He needs to keep the watchmen here and it's only proper 
+that the Player-­heroes investigate since they’ve encountered 
+the creature before. Once all is agreed upon, if Drogo is in 
+the Company, then Gorbadoc puts a hand on his shoulder 
+and tells him “Thank you, son. For what you’re doing for my 
+family and my daughter. You and your family will always have 
+a room at Brandy Hall.”
+The characters arrive at Crickhollow after a brief early 
+morning walk from Brandy Hall a few miles away, but find no 
+damage to the house itself. Anyone who searches the prop-
+erty discovers signs of disturbance — trampled flower beds, 
+bark ripped from trees as if by animal claws, the carcasses of 
+a few dead rabbits, and most disturbing of all, great gouges 
+in the rear door of Rollo Boffin’s house. 
+Anyone who makes a SCAN roll spots a small trail 
+leading towards the eastern end of the property 
+that appears to dip and run to the very High Hay 
+itself. Once they get near it, the Player-­heroes get the 
+uncanny sense that they are being watched.
+It is then that the beast strikes again! Leaping from a long 
+shadow cast by the rising sun against the High Hay, the horrid 
+creature lunges at the nearest Player-­hero! But the creature 
+is not moving in for the kill — after a single successful attack 
+or after being hit, the beast runs down the narrow path to 
+the end of the property and disappears.
+The path from Crickhollow to the High Hay dips very 
+low as it goes on for some time, eventually coming to a brick 
+lined gap in the Hedge where it ends in a set of thick iron 
+bars. Though once forming a sturdy barrier, the gate appears 
+to have been bent and twisted by some creature from the Old 
+Forest trying to get in. 
+Careful examination of the gate via a HUNTING or SCAN 
+roll reveals a few tufts of black fur caught in a hinge. It is clear 
+Gorbadoc Brandybuck
+James Smith (Order #47812382)
+
+To Soothe a Savage Beast
+29
+that the black beast came this way, from somewhere inside 
+the Old Forest. If they do not dare to take the hunt for the 
+terrible creature into such a gloomy and dangerous place, it 
+will only continue to plague the people of the Eastfarthing 
+for countless nights to come.
+part three: the old forest
+The Player-­heroes have now truly passed beyond the safety of 
+the Shire. After slipping through the tiny iron gate beneath 
+the High Hay and into the Old Forest proper, they catch their 
+first full look at this strange and legendary wood.
+The Old Forest. Countless tales are told, from Buckland to 
+the White Downs, about the strange affairs of this untamed 
+wild. To your surprise, the forest itself does not immediately 
+leap out and attack you as soon as you step past the bent 
+iron gate and fully into the woods. 
+Instead, a thin collection of trees, bent and gnarled, sur-
+rounds you, just out of reach, their full branches not quite 
+touching you. A wide path, barely visible from the gate, runs 
+east and slightly to the north, over a low rise where you see 
+a break in the trees. After a brief walk through moss-­covered 
+trees growing in countless shapes and sizes, you come to a 
+wide, bare space where no trees grow. It forms a wide circle, 
+and the sun reaches down, unobscured by the thick canopy 
+of reaching branches and wide leaves.
+Beyond this, the Old Forest grows thick and free. Trees, 
+gnarled and twisted, with great roots sticking up from the 
+ground and dipping back down again, grow freely, and 
+there is little in the way of a path as the ground continues a 
+slow ascent, and the sense that you are an unwanted visitor 
+and are being watched grows in your mind. In this wild and 
+twisted place, it is clear that the Burnt Beast will have the 
+advantage, and your hunt will be most difficult.
+Player-­heroes asking the Lore­master what they know 
+about tales of the Old Forest may make a LORE roll. 
+With a success, they learn that rumour has it that the 
+forest is alive and actively dislikes visitors, with some 
+believing that the trees themselves actually move to 
+obstruct travellers with twisting roots and tangling 
+branches. Long ago some ­Hobbits actually drove the 
+Old Forest back when the wood itself moved and tried 
+to attack the hedge. Bucklanders travelled beyond the 
+High Hay and drove it away with fire. One or more  
+icons include knowledge that the Old Forest is said to 
+be the home of a wandering spirit that speaks to trees 
+and bends the beasts that live in it to his will.
+THE HUNT FOR THE BURNT BEAST
+The Lore­master should ask the players which one (and 
+only one) of the Player-­heroes will act as the scout for the 
+group. The scout is in charge of trying to maintain orien-
+tation and prevent them from getting lost in the strange 
+and shifting Old Forest. All Player-­heroes not serving as the 
+scout are instead searching for signs of the beast's passage 
+as hunters. This could include tufts of fur, blood, or paw 
+prints. There is no limit to the number of Player-­heroes 
+attempting to track the beast, though no character can be 
+both scout and hunter.
+The scout must make a single EXPLORE roll, while 
+the hunters must accumulate 3 successful HUNTING 
+rolls. If the EXPLORE roll fails, the HUNTING rolls 
+lose (1d); if it succeeds with one or more  icons, they 
+gain (1d) instead.
+On any failed HUNTING roll, the Lore­master must roll 
+a Feat Die to determine what type of strange encoun-
+ter occurs, using the table found on page 49 of The 
+Shire. Likewise, for every couple of hours of searching, 
+if the Player-­heroes have not rolled 3 successes, the 
+Lore­master rolls on the table again. 
+Once the required HUNTING successes have been reached, 
+the Company finds the Burnt Beast, which prowls near the 
+banks of the Withywindle, prepared to ambush the charac-
+ters. Go to Part Four.
+ANGERING THE OLD FOREST
+Player-­heroes who brandish axes or speak ill of 
+the forest may find the trees treat them with even 
+more contempt and malice than before. Insults 
+and threats spoken aloud in the Old Forest can 
+make this journey even more dangerous, and the 
+Lore­master should consider increasing the num-
+ber of HUNTING rolls required by 1 if they speak 
+so foolishly.
+James Smith (Order #47812382)
+
+ADVENTURES
+30
+part four: burning battle
+The Player-­heroes have finally cornered the Burnt Beast, 
+and can put an end to the troubles it is bringing to the 
+Eastfarthing!
+The thick woodland opens ever so slightly to reveal a great 
+thorn thicket that is impossibly large and twisted. From 
+under the strangling vines, you see a familiar pair of 
+burning eyes, as the Burnt Beast slithers forth from the 
+darkness. An instant later, a chill runs down your spine, 
+as a second pair of eyes appears in the darkness only a 
+moment before another of these horrid creatures comes forth, 
+intent on devouring you and your friends. It is not one 
+of these shadowed predators prowling the Old Forest, but 
+a fierce mated pair that has been cornered and driven to 
+defend the bramble-­ridden thorn hedge they’ve taken as 
+home. They leap forward, prepared to finish you and your 
+friends off now that there are no people of the Shire to hear 
+your screams. 
+The Burnt Beasts, now revealed to be a pair and not a singu-
+lar creature, are cornered and threatened, fighting fiercely. 
+More dangerous than anything the conspirators have faced 
+so far, this seems a true life-­or-­death situation — the Burnt 
+Beasts have drawn the Player-­heroes out of the Shire and 
+into their territory. 
+The Lore­master should refer to the stats presented on 
+page 27 for both Burnt Beasts.
+ANCIENT SONGS AND NEW FRIENDS
+Fortunately, all the commotion going on in the Old Forest 
+has not gone unnoticed. Depending on how the Player-­heroes 
+have acted through the course of their adventures, aid may 
+soon arrive to help them in this dire time. 
+After a number of rounds of battle, Tom Bombadil 
+arrives and chases away the beasts. The number of 
+rounds is equal to 6, minus 1 for each instance that 
+the Player-­heroes have shown kindness to the animal 
+inhabitants of the Shire (including, but not limited to, 
+the owl at Waymeet, Firework the dog, the Squirrels 
+of Woody End, etc.).
+If the Player-­heroes defeat the Burnt Beasts before Tom’s 
+arrival, this changes little, and the situation still plays out 
+narratively as before. They simply flee into the forest and 
+Tom arrives moments later.
+Breaking through your fear and weariness, you hear a 
+strange voice rise, and the black beasts draw back from you, 
+looking towards the sound. Dancing as though at a spring 
+festival, you see a wanderer merrily skipping about in yellow 
+boots. Taller than a ­Hobbit, though not as tall as a Man, his 
+face sports a careful smile, and he sweeps off his great floppy 
+hat with a bow to you, and then again to the two beasts! 
+Rising again, replacing his hat and straightening his blue 
+jacket, he speaks in a kind of sing-­song rhyme.
+“Hey ho, silly ho, tramp across the forest
+Little creatures under foot, black dogs are the sorest
+Go now, silly dogs, cast away your ire
+­Hobbits only hope to help, 
+Come now, little dogs, no need to be so dire”
+Tom prances over to the Player-­heroes, and the Burnt Beasts 
+break off their attack and flee from his presence. He pays 
+them little heed for his part, much more interested in 
+the Player-­heroes. Instead, he sings his brief rhyme and 
+then merrily bids the ­Hobbits to follow him to his house, 
+where they can find refreshment and recover. (The Lore­
+master can read more about Tom Bombadil on page 51 of 
+The Shire). 
+While the Player-­heroes rest for the evening in the House 
+of Bombadil, Tom reveals what he knows about the true 
+nature of the Burnt Beasts: They were once hounds owned 
+by a lord of Men, residing long ago in a tower of stone which 
+rose among the hills which are now known as the Barrow-­
+downs, beyond the Old Forest. In a time of terrible war, the 
+lord perished among the flames, and his faithful hounds with 
+him. When evil spirits descended upon the Barrow-­downs, 
+many years later, the hounds returned as dark reflections of 
+what they once were. 
+They are now terrible creatures, but yet, they are not 
+entirely evil, says Tom — something of their faithful nature 
+remains, and they seldom attempt to kill. But their malice 
+is growing year after year, as if the ill-­will of the Old Forest 
+itself is slowly taking over. Can it be that something can be 
+done to remind them of what it means to be steadfast and 
+true? Can they be given peace? Perhaps, Tom asks, if the 
+Player-­heroes are willing to help them find their way back to 
+being fine companion hounds, they could be released from 
+their wretched state.
+If the Player-­heroes agree, Tom tells them that the Burnt 
+Beasts must be again given proper names, and if the Player-­
+heroes will give them such names, the true and loyal nature 
+James Smith (Order #47812382)
+
+To Soothe a Savage Beast
+31
+of their hearts can perhaps be restored. When asked why Tom 
+couldn’t name them himself, he says: 
+“Tom doesn’t fear the hounds, and the hounds leave Tom 
+be, my merries! Listen to Old Tom’s songs and sing them back, 
+recalling hearth and home. Gentle voices and kind souls will 
+cast away the doom.” 
+Tom teaches them several of his strange songs, as if 
+they were simple children’s rhymes, then merrily bids the 
+characters get a good night’s rest in his home. Come dawn, 
+they can set out with a song in their hearts to restore the 
+Burnt Beasts.
+RETURN TO THE LAIR
+At dawn, the Player-­heroes awake to find Tom has gone out to 
+collect river lilies for his wife. Goldberry tells the Player-­heroes 
+that the Burnt Beasts are still prowling around their lair in 
+the nearby thorny thicket. Upon returning to the thicket, the 
+Player-­heroes spot the mated pair of creatures at once. They 
+move to attack as soon as the conspirators arrive.
+Though the Player-­heroes can kill the Burnt Beasts with 
+their weapons, their death is not permanent. They will rise 
+again, and return to plague the Shire, unless they are slain 
+using blades of Westernesse or similar magical weapons. 
+Instead, some among the Player-­heroes must hold off the 
+savage beasts while others sing the songs they learned from 
+Bombadil. 
+This requires the conspirators to pass 3 SONG rolls.  
+Any number of Player-­heroes not engaged with the 
+Burnt Beasts can sing. 
+If successful, the Burnt Beasts become light of heart, as all 
+darkness and sorrow is washed away from their spirit. At that 
+point, the Player-­heroes can give them a name. Once the 
+power of Tom’s song and their new names have taken hold, 
+the ashen features of the Burnt Beasts fade away, and their 
+eyes brighten from fiery red to a gentle colour. The hounds, 
+joyful, cheerful creatures once more, run away to play on 
+the paths of the Old Forest, running beyond the edge of the 
+Player-­heroes’ sight. 
+epilogue
+Having released the hounds from their curse, the Player-­
+heroes make their way through the Old Forest back towards 
+the Shire, and oddly enough, the woods do not seem to 
+impede their travel. Once back in Buckland, the Player-­heroes 
+are given a warm welcome by Gorbadoc, and another night 
+of fine eating and resting before crossing the Brandy­wine 
+back into the Marish. 
+The Lore­master can read or paraphrase the following text.
+You arrive at Maggot’s house just in time for dinner, and 
+find the farmer intent on rebuilding his chicken coop. As 
+you greet Maggot, to your surprise and amazement the once-­
+cursed dogs appear out of nowhere and run to Maggot, bark-
+ing merrily. At first, the farmer is a bit fearful, but both dogs 
+tackle him and begin to lick him and play with him. Slowly, 
+Maggot’s demeanour changes, and he begins to pet and play 
+with them. In time, Maggot gently brings them to heel and 
+calls you to join him for dinner. 
+As you sit at the dinner table, Maggot asks if these fine 
+beasts have names. You recount what happened in the Old 
+Forest, and as you do so, you realize that the friendliness 
+of the two dogs towards Maggot must be a sort of gift from 
+Tom — could it be that they know each other?
+Over a hearty home-­cooked meal, Maggot says that he was not 
+one to keep beasts around, but these dogs seem rather fond 
+of him, and they might make fine breeding stock for years 
+to come. If any fierceness remains in their hearts, they’ll be 
+fine protectors for his family. He thanks the Player-­heroes for 
+their aid and asks them if they’ll stay for the night.
+Come morning, Bilbo declares that he has had a wonder-
+ful little adventure, and enough proper research has been 
+gathered for his book. He kindly thanks the Player-­heroes for 
+their involvement and declares that they all shall be invited 
+to the next great party he throws, and every party to come. 
+As time goes on, Bilbo becomes more reclusive, and the 
+other ­Hobbits return to their lives. Gossip regarding their 
+mischief fades away over the years, and life once again returns 
+to normal in the Shire, for a few years at least... 
+James Smith (Order #47812382)
+
+He looked at maps, and wondered what lay beyond their edges:  
+maps made in the Shire showed mostly white spaces beyond its borders.
+This page marks the end of your adventures in the Shire for the moment! You can continue 
+by creating your own, using the information contained in The Shire. You can further widen 
+your exploration of Middle-earth with the second edition of The One Ring roleplaying game.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)

--- a/static/text/the-one-ring/the-one-ring-starter-rules.txt
+++ b/static/text/the-one-ring/the-one-ring-starter-rules.txt
@@ -1,0 +1,1548 @@
+the rules
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+LEAD WRITERS
+Francesco Nepitello and Lorenzo Perassi
+GAME DESIGNERS
+Francesco Nepitello and Marco Maggi
+ADDITIONAL RULES DEVELOPMENT
+Michele Garbuggio
+CONCEPT ART
+Alvaro Tapia
+COVER ART
+Martin Grip
+OTHER ART
+Alvaro Tapia, Martin Grip, Jan Pospíšil, Niklas Brandt, Henrik Rosenborg,  
+Antonio De Luca, Federica Costantini, Melissa Spandri, Giuditta Betti
+GRAPHIC DESIGN
+Christian Granath, Dan Algstrand, Niklas Brandt
+MAPS
+Francesco Mattioli
+EDITORS
+John Marron, Jacob Rodgers
+PROJECT MANAGERS
+Martin Takaichi, Tomas Härenstam
+BRAND MANAGER
+Robert Hyde / Sophisticated Games
+EVENT MANAGER
+Anna Westerling
+PR MANAGER
+Boel Bermann
+STREAMING
+Doug Shute, Matthew Jowett
+ISBN
+978-91-89143-48-7
+SPECIAL THANKS TO
+Claudio Muraro and Umberto Pignatelli
+PLAYTESTERS
+Adam Rawson, Agnes Rudbo, Amanda Stenback, Andreas Lundström, Anna Ave, Charlie Conley, Chiara Ave, 
+Dan Price, Daniel Raab, Dennis Detwiller, Francisca Hoogenboom, Giuliano Nepitello, Kathleen Kiker, 
+Kyle Wood, Lorenzo Perassi, Luca Donati, Maja Emilie Søgaard Widerberg, Maner Samuel, Marco Beltramino, 
+Michael Kiker, Michela Baù, Peter Bergman, Peter Link, Ric Wagner, Stephen Buck, Steven Nguyen Dinh, 
+Umberto Pignatelli, Vanessa Ratschinske. 
+The One Ring, Middle-­earth, and The Lord of the Rings and the characters, items, events, and places therein  
+are trademarks or registered trademarks of the Saul Zaentz Company d/b/a Middle-­earth Enterprises (SZC)  
+and are used under license by Sophisticated Games Ltd. and their respective licensees. All rights reserved.
+James Smith (Order #47812382)
+
+THE RULES
+2
+PROLOGUE
+His sword, Sting, Bilbo hung over his fireplace,  
+and his coat of marvellous mail, the gift of the Dwarves  
+from the Dragon-­hoard, he lent to a museum,  
+to the Michel Delving Mathom-­house in fact.  
+But he kept in a drawer at Bag End the old cloak and 
+hood that he had worn on his travels; and the ring, 
+secured by a fine chain, remained in his pocket.
+James Smith (Order #47812382)
+
+Prologue
+3
+From a letter from Bilbo Baggins, Esq. to Balin son of Fundin.
+Dearest Balin,
+Almost six years have passed already since the last time you were here. 
+I remember very well everything you and Gandalf said when we met. 
+You were alarmed, and I took your warnings to heart, but I don’t think 
+you would find it surprising to know that news of a nameless threat is 
+hard to believe here in the dear old Shire. Gandalf came to see me again, 
+on several occasions. He seems to care about our friendship, and he says 
+I should indeed be worried, but his vague words of warning make even less 
+of a dent in the general sense of peace and protection that we enjoy here, 
+away in the north-­west.
+But don’t think that I am completely clueless! All I need is to have a look 
+at... the things I collected in my adventures to remember that there 
+is a wide and dangerous world out there. Sometimes I even miss it, the 
+road, the thrill, the narrow escapes. It’s my Tookish side. But then I look 
+at my beautiful garden, my snapdragons and sunflowers, my trailing 
+nasturtians... how they glow, red and golden, more beautiful than any 
+Dragon-­hoard that ever was, and I am back to being a Baggins.
+I hope what I say won’t be too much of a disappointment to you. 
+You haven’t asked yet, but I know that you mean to invite me to join 
+you in that Moria adventure you are always talking about. I am afraid 
+that I have spent enough time crawling in the dark under the Misty 
+Mountains not to wish to do that ever again! But there’s a good bunch of 
+eager lads and lasses here that you might find to your liking. Why, they 
+are just waiting for no more than a nod in their direction from me or 
+from our Grey friend to go off into the blue on mad adventures! Theirs is 
+an age that is more appropriate to that type of business, believe me, an
+d 
+I have taught them a thing or two. I suspect that Gandalf has too...
+James Smith (Order #47812382)
+
+THE RULES
+4
+example of play
+You struck some very good deals at the market today, and on your 
+way home you decided to celebrate at The Green Dragon Inn. But 
+now you all regret that decision, as the sun has already set in the 
+west and dark clouds are gathering.
+In fact, you are still crossing the open fields towards your home 
+in the Green Hill Country when it starts to rain; it will take you 
+at least another hour of restless march to get home. What’s worse, 
+since when it got dark, you heard a wolf howling. Twice, and the 
+second time was closer.
+THE LORE­MASTER: What do you do?
+PLAYER-­HERO 1 (PLAYING LOBELIA): I stop and look around 
+for a shelter.
+THE LORE­MASTER: It’s dark already, and you can’t see clearly; 
+make a SCAN roll.
+PLAYER-­HERO 1 (LOBELIA): I have a rating of 2 in SCAN, I want 
+to spend a point of Hope to add 1 more.
+THE LORE­MASTER: Don’t forget to roll one Feat die too.
+PLAYER-­HERO 1 (LOBELIA): Yes, of course. Right, my WITS TN 
+is 14. Let’s see; 9-1-3-5. I succeeded!
+THE LORE­MASTER: On the left you see a small, low building. If 
+you want to reach it you’ll have to leave the road.
+PLAYER-­HERO 1 (LOBELIA): Speaking in character: “Let’s go there, 
+at least we’ll be dry.”
+PLAYER-­HERO 2 (PLAYING PALADIN): I don’t like the idea of leav-
+ing the road, and get closer to the trees, but I don’t see other options. 
+I shout back to Lobelia: “I’m with you!”
+THE LORE­MASTER: As you reach the building, you take a look at 
+it, at the dim light of your lanterns. It’s a simple stone construction 
+with a roof covered in turf, used by shepherds. No sounds or smoke 
+come out of it.
+PLAYER-­HERO 2 (PALADIN): I look for the door to get inside.
+THE LORE­MASTER: You find it easily, but it’s closed. There is a 
+wooden latch, tied with a rope. The knot looks tight.
+PLAYER-­HERO 1 (LOBELIA): We have no time to lose, I try to 
+force it open.
+PLAYER-­HERO 2 (PALADIN): “What are you doing? We can’t dam-
+age someone else’s property!” Can I loosen the knot?
+THE LORE­MASTER: You can try, roll CRAFT.
+PLAYER-­HERO 2 (PALADIN): Let me see; STRENGTH TN 17, 
+CRAFT rating is 3. I roll 6-2-3-2, only 13… I didn’t do great.
+PLAYER-­HERO 1 (LOBELIA): Ok, it’s time to use a bit of brute force…
+James Smith (Order #47812382)
+
+Prologue
+5
+“THIS IS THE MASTER-­RING,  
+THE ONE RING TO RULE THEM ALL.”
+It is the year 2960 of the Third Age and the Shadow is 
+returning. Twenty years ago, an alliance of Elves, Men, 
+and Dwarves defeated a horde of Orcs and Wild Wolves, 
+under a sky darkened by Giant Bats, inaugurating a new 
+era of prosperity for the Free Peoples. But twenty years 
+is a long time for peace to last, and in many dark corners 
+of the Earth a shadow is lengthening once again.
+Rumours of strange things happening outside the 
+borders of civilised lands are spreading with increas-
+ing regularity, and while they are dismissed by most 
+as fireside-­tales and children’s stories, they sometimes 
+reach the ears of individuals who recognise the sinister 
+truth they hide.
+These are restless warriors, curious scholars and wan-
+derers, always eager to seek what was lost or explore 
+what was forgotten. Ordinary people call them adven-
+turers, and when they prevail, they hail them as heroes. 
+But if they fail, no one will even remember their names…
+This is the premise of The One Ring, a roleplaying 
+game based on The ­Hobbit and The Lord of the Rings, two 
+extraordinary works of fiction by the beloved author and 
+respected academic, John Ronald Reuel ­Tolkien. With 
+these books, ­Tolkien introduced readers to his greatest 
+creation, the world of Middle-­earth, a mythic land from 
+a remote past. With The One Ring, Middle-­earth is yours 
+to explore — you will travel the land searching for clues 
+about the return of the Shadow, and have the chance to 
+play a part in the struggle against the Enemy.
+THE TWILIGHT OF THE THIRD AGE
+The One Ring is set in the time period running from the 
+events narrated in The ­Hobbit to those told in The Lord 
+of the Rings. Encompassing more than six decades, this 
+period is ushered in when Bilbo the ­Hobbit finds the Rul-
+ing Ring, and culminates with the war fought by the Free 
+Peoples against the Dark Lord Sauron, and the destruc-
+tion of the Ring.
+Players of The One Ring create a Company of heroes 
+— Hobbits, Dwarves, Elves, and Men, seeking adventure 
+in the Lone-­lands of Eriador. It is a desolate country, a 
+vast region that once saw the glory of the North Kingdom 
+of the Dúnedain, the Men of the West. Here, many wars 
+were fought, and countless ruins dot its landscape. Shad-
+ows move along its paths, and not all of them belong 
+to the living.
+It is in Eriador that the One Ring lies, dormant, a 
+seed of the past that will one day bring the end of this 
+age of the world.
+THE LORE­MASTER: Can both of you please make an AWARE-
+NESS roll?
+PLAYER-­HERO 1 (LOBELIA): My STRENGTH TN is 18; Ah! 
+I rolled an Eye of Sauron 3-4-1, didn’t pass it.
+PLAYER-­HERO 2 (PALADIN): TN 17; 5-3-3-4, neither did I!
+THE LORE­MASTER: You were so busy discussing and trying to open 
+the door that did not notice the stranger until the very last moment. It’s 
+a tall, dark and hooded figure, now raising a wicked-­looking longsword!
+PLAYER-­HERO 2 (PALADIN): I draw my short sword to parry!
+THE LORE­MASTER: You were caught by surprise, you can’t act 
+this round. With a single blow, the sword cuts the rope in two. While 
+sheathing it, the figure finally speaks with a warm, female voice: 
+“Forgive my intrusion, my small friends, my name is Amantadine. 
+Would you mind sharing this humble shed with me?”
+The short “unfinished tale” above is an example of what can 
+happen during play. The One Ring is what is called a pen-­and-­
+paper roleplaying game. Thanks to video and online games, 
+millions of people are familiar with this form of entertain-
+ment, where players create fictional heroes and explore 
+shared worlds populated by computer-­controlled creatures 
+and, in online games, accessed by a multitude of other players.
+In The One Ring Starter Set, players choose characters and 
+meet face-­to-­face around a table or across the world on video, 
+and the computer is replaced by one person taking the man-
+tle of the Lore­master — a director, a referee, and a narrator.
+The game can be played with as few as two people (one 
+player plus the Lore­master), and with as many as six players 
+or more. All that is needed are dice, paper, pencils, imagina-
+tion, and a love for ­Tolkien’s imaginary world.
+James Smith (Order #47812382)
+
+THE RULES
+6
+in the shire
+This is a story of how a Baggins had an adventure,  
+found himself doing and saying things altogether unexpected.
+For generations of fans, the Shire has been the gateway to 
+Middle-­earth. Both the Quest for Erebor told in The ­Hobbit 
+and that to Mount Doom described in The Lord of the Rings 
+start here, with Bilbo and Frodo providing the readers with 
+a first-­person perspective — a point of view allowing them to 
+unravel the complexity of the world of Arda step by step. It 
+is a small world, almost fable-­like, where a single Wild Wolf 
+poses a serious threat, and a Wizard is maybe nothing more 
+than an eccentric fireworks-­maker.
+In the same way, this Starter Set describes the Shire as 
+an introductory, less dangerous setting for new (and maybe 
+younger) players of The One Ring roleplaying game:
+By using the material provided in this boxed set, the 
+players will have a taste of the game and the world, 
+using a simpler set of rules and adventuring within lim-
+ited boundaries. Once they familiarize with the game 
+mechanics and the scope of the game, players of the 
+Starter Set will be ready to take on The One Ring, and 
+venture across the vast expanses of Eriador and beyond.
+These rules contain everything you need to quickly set up a game 
+and play the scenarios presented in The Adventures, using the 
+pre­generated characters contained in the box.
+the player-­heroes
+With the exception of the Lore­master, each player takes the 
+role of a single Player-­hero, a fictional character whose attri-
+butes are inspired by those of the protagonists of the stories 
+by J.R.R. ­Tolkien.
+This Starter Set is played using a number of pre-­
+generated characters, ready-­to-­play heroes setting 
+the players on the road to adventure in no time. The 
+available characters include esteemed Hobbits like 
+Drogo Baggins, Paladin Took, Primula Brandybuck, 
+Lobelia Bracegirdle, and more.
+To enter Middle-­earth, players must simply step into their 
+characters’ shoes, trying to think as they would think and 
+react as they would react. It is a game of make-­believe, a story 
+in the making, created in collaboration with the Lore­master.
+the lore­master
+The Lore­master doesn’t take the role of a single character, 
+but is instead the player in charge of describing the setting 
+and managing what happens to the Player-­heroes when they 
+interact with the game world.
+The Lore­master begins each session of play by setting 
+the scene, playing the parts of the people and crea-
+tures the characters encounter — called Lore­master 
+characters or Adversaries, based on whether they are 
+peaceful or hostile — and adjudicating the conse-
+quences of the heroes’ actions.
+The Lore­master is the eyes and ears of the Player-­heroes, in 
+charge of describing the locales where the action is taking 
+place and playing the parts of the people they meet, using the 
+rules to fairly adjudicate the outcome of their actions. To do 
+so, the Lore­master interprets and reinvents Middle-­earth as 
+a setting for the players to explore. The ultimate goal of the 
+Lore­master is to provide the premise for the creation of a new 
+epic, focused entirely around the deeds of the Player-­heroes.
+ENTERING MIDDLE-­EARTH…
+The aim of The One Ring is to let players feel what 
+it means to go adventuring in a wild and peril-
+ous land from a forgotten past. It is a threatening 
+world that has more in common with the world 
+depicted in epic sagas or with the Dark Ages of 
+Europe than with our contemporary world.
+Players are invited to leave the age of infor-
+mation and fast travel behind, and adopt the point 
+of view of individuals whose horizons often didn’t 
+extend further than a few miles from their birthplace.
+The landscape revealed by this perspective is a 
+world with uncertain boundaries, and only vague 
+hints of distant realms and the folks who inhabit 
+them; a place that for these very reasons offers plenty 
+of opportunities for exploration and adventure.
+James Smith (Order #47812382)
+
+Prologue
+7
+structure of the game
+“Still, I wonder if we shall ever be put into songs or tales. We’re in one, of course; 
+but I mean: put into words, you know, told by the fireside, or read out of a 
+great big book with red and black letters, years and years afterwards.”
+Story-­building is a fundamental component of The One Ring. 
+But it isn’t about hearing a story being told, but about creating it 
+over the course of the game, as the result of the interaction at the 
+gaming table between the Lore­master and the Player-­heroes.
+having adventures
+A session of play is played as a series of scenes, connected 
+sequentially in a wider narrative arc. A scene is a single epi-
+sode focusing on the Company, or part of it, facing some 
+kind of challenge, preparing for one, or recovering from it.
+It is up to the Lore­master to initially frame each 
+scene, especially those that are putting the Company 
+in danger.
+To frame a scene, the Lore­master needs to first describe the 
+location where the action is taking place, and who is there 
+among the Player-­heroes and their potential adversaries 
+or allies; then, the Lore­master defines the challenge that 
+the Company is facing, considering the perspective of each 
+involved Player-­hero.
+Once the Lore­master is done setting up the scene, 
+the players proceed to describe how their characters 
+react to the situation.
+In particular, players need to choose what actions their Player-­
+heroes take to investigate and resolve the challenge facing 
+them. Players have full control over what their heroes do and 
+how they do it, but it is the Lore­master that determines how 
+every part of the world — from Lore­master characters to 
+creatures and the environment — reacts to what the Player-­
+heroes do.
+In general, to play out a scene and determine its conse-
+quences, the Lore­master and the players need nothing 
+more than common sense and the rules concerning 
+Action Resolution described on page 8. (A notable 
+exception are those scenes that require the applica-
+tion of the rules for Combat described on page 22 — 
+luckily, a rare occurrence in the Shire!)
+James Smith (Order #47812382)
+
+THE RULES
+8
+action resolution
+Of the various burglarious proceedings he had heard of,  
+picking the trolls’ pockets seemed the least difficult…
+As previously explained, a game session takes the form of a con-
+tinuous conversation between the Lore­master and the players. 
+There are no turns, and the dialogue alternates between the 
+Lore­master and the players who collaborate in bringing to life a 
+series of scenes in which the Player-­heroes are the protagonists.
+The main way for the players to participate in a scene is 
+simply to tell the Lore­master what their Player-­heroes 
+are doing, and how they intend to do it. In game terms, 
+this is called taking an action.
+when to roll
+To put it simply, the Lore­master should ask for a die roll only 
+if there is a possibility that a player’s chosen action might fail.
+If the description of an action does not leave any 
+doubts about its outcome, there’s no need to make a 
+roll — the action succeeds automatically.
+But this is not all there is to it: resorting to a roll should be 
+considered exclusively if the action or its goal fall into one 
+of the following instances:
+1.	 DANGER — Roll if the action is dangerous.
+If the Player-­hero does not risk anything by failing, 
+do not roll.
+2.	 KNOWLEDGE — Roll if the action aims to obtain informa-
+tion that is not immediately available.
+If the knowledge that the heroes are looking for is 
+not secret or hidden, do not roll.
+3.	 MANIPULATION — Roll if the action intends to influence 
+one or more uncooperative Lore­master characters.
+If what the heroes ask of them is coherent with 
+their motives, do not roll.
+the one ring dice
+The One Ring makes use of a specialised set of dice, including 
+six 6-sided dice (also called Success Dice) and two 12-sided 
+dice with two special icons (called the Feat dice).
+A set of The One Ring dice (with exactly the right amount 
+of dice for use with the game) is included in the Starter 
+Set, but players may find it useful to bring some more as 
+it will be more convenient for each player to have a set 
+close at hand.
+making rolls
+Once the necessity for a die roll has been established, it must 
+be determined who is going to make the roll, and which ability 
+is most appropriate for the action.
+WHO ROLLS
+Determining who is going to make the roll is easy in the case 
+of actions chosen by the players, but can be less so if the roll 
+is being made as a reaction to something described by the 
+Lore­master.
+Generally, it is highly advisable to have a single player 
+make a roll, except when something involves every-
+one in the group. To do so, the players simply choose 
+the Player-­hero who is best suited to the task at hand.
+WHICH ABILITY
+The ability to use depends mostly on the type of roll:
+	
+♦
+SKILL ROLLS. By far the most common type of 
+actions, Skill rolls are required whenever a Player-­hero 
+attempts to do something that can be accomplished 
+using one of the 18 Skills listed on a character sheet.
+SCENES IN BRIEF
+Scenes in game work as follows:
+1.	 The Lore­master describes a situation requir-
+ing the players to make decisions.
+2.	 The players investigate the situation, con-
+sidering their options. Once decided, they 
+describe their action to the Lore­master.
+3.	 The Lore­master evaluates the plan of the 
+players, and adjudicates whether to just 
+‘say yes’ and grant them what they want to 
+achieve, or ask for a die roll.
+More information about scenes is presented 
+below in the Adventuring chapter, page 20.
+James Smith (Order #47812382)
+
+Prologue
+9
+	
+♦
+COMBAT ROLLS. When involved in a fight, the Player-­
+heroes rely mostly on their Combat Proficiencies to 
+make attack rolls, and on PROTECTION rolls to avoid 
+being injured when hit.
+Finally, the Lore­master may ask the players to make VALOUR 
+and WISDOM rolls, prompted by sources such as fear, or sor-
+cery, as indicated in the text for The Adventures.
+MAKE THE ROLL
+Once determined the correct ability, proceed to make the 
+roll employing its numerical rating (all abilities that can be 
+used to make a roll are given a value ranging from 1 to 6):
+1.	 Roll one Feat Die, plus a number of Success Dice 
+equal to the rating of the appropriate ability (roll only 
+one Feat Die if the rating is 0).
+2.	 Add up the numerical results on all dice, comparing 
+the total to the Target Number (TN) associated with 
+the rolled ability.
+In general terms, if the rolled total is equal to or higher than 
+the TN, the roll is a success; otherwise, it has failed:
+A successful roll indicates that the acting Player-­hero 
+achieves their goal, while a failure means that some-
+thing went wrong and that the desired goal was not 
+achieved.
+Some rules state explicitly what happens in game terms in 
+case of a failure or a success — combat, for example, while 
+other situations require creativity from the players and the 
+Lore­master.
+In any case, the consequences of both a successful and 
+a failed roll always determine a well-­defined change 
+in the gameplay.
+REPEATING A ROLL
+As a rule, players only have one attempt at anything that is 
+resolved with a die roll — when they succeed or fail, they 
+have done their best.
+If the Lore­master allows it, a failed action can be 
+attempted again by the same Player-­hero if they try again 
+using a different ability, effectively representing a different 
+approach to the same problem.
+Of course, a Player-­hero who is given a second chance 
+must always cope with the consequences of having failed the 
+first time…
+how to read the feat dice
+Each Feat Die shows numbers ranging from 1 to 10, and two 
+special icons: a Gandalf rune ( ) and the Eye of Sauron (
+). 
+The two icons are normally read as follows:
+	
+♦The  rune is the greatest result you can get on a 
+Feat Die. When the die comes up showing the  
+rune, the action succeeds regardless of whether the 
+total result of the roll was enough to match or beat 
+the TN or not.
+	
+♦The 
+ icon is considered to be the worst result possi-
+ble on a Feat Die. When the Feat Die comes up show-
+ing the 
+ icon, the Feat Die result counts as a zero.
+how to read the success dice
+Success Dice are special 6-sided dice, customised to show the 
+numbers 1, 2, and 3 in outline, and the numbers 4, 5, and 
+6 in solid colour. In addition, a Success icon — the Elvish 
+numeral 1 ( ) — appears along with the number 6. Success 
+Dice are always rolled together with one Feat Die.
+Add the results on all Success Dice to the result of the 
+Feat die, with any  icons rolled indicating a superior 
+result on a success (see Degree of Success overleaf).
+target numbers
+All abilities used in the game are associated with a Target 
+Number, a numerical value that the roll result must match 
+or beat.
+	
+♦Most rolls made by the Player-­heroes are made against 
+three Attribute Target Numbers (Attribute TNs, for 
+short), based on their ratings in STRENGTH, HEART, 
+and WITS.
+	
+♦Each Attribute TN in the Starter Set is equal to 18 
+minus its corresponding Attribute score (the full The 
+One Ring Core Rules use 20 instead).
+EXAMPLE:
+Scouting ahead, Paladin Took has a chance to notice a group 
+of brigands setting up an ambush. He has an AWARENESS 
+skill of 
+ (2), so he rolls a Feat die plus two Success dice, 
+adding up the results of all dice rolled. As AWARENESS 
+is a STRENGTH Skill, the roll result is compared against 
+Paladin’s STRENGTH TN, which is 15. With the Success 
+dice showing 4 and 5, and the Feat Die an 8, Paladin’s 
+player does not need to do much maths to know that the 
+­Hobbit succeeded.
+James Smith (Order #47812382)
+
+THE RULES
+10
+degree of success
+A roll result that achieves its Target Number (or resulted in 
+the  rune) and produces one or more 
+ icons is an out-
+come of a superior quality — a musician performs particularly 
+well, a look-­out spots enemies at a longer distance, an orator 
+succeeds in galvanizing a larger audience. The greater the 
+number of Success icons rolled, the better:
+	
+♦(—) If no  icons were scored, the action was success-
+ful, but didn’t achieve anything beyond the bare mini-
+mum (a success).
+	
+♦
+ If a single  was scored, then the Player-­hero’s 
+accomplishment was out of the ordinary (a great 
+success).
+	
+♦
++ If two or more  icons were scored, the result was 
+absolutely exceptional and memorable (an extraordi-
+nary success).
+die roll modifiers
+Following are a number of variations upon the core rules of 
+the game. They represent those advantages (and drawbacks!) 
+that affect the Player-­heroes as the most explicit demonstra-
+tion of their ability as heroes.
+FAVOURED ROLLS
+A Favoured roll happens when a Player-­hero possesses a spe-
+cial affinity for a task.
+When making a Favoured roll, players roll two Feat dice 
+instead of one, keeping the best result among the two.
+Typical sources of Favoured rolls are a Player-­hero’s Favoured 
+Skills (see also Skills, page 14).
+ILL-­FAVOURED ROLLS
+The opposite of a Favoured roll, a roll is made Ill-­favoured 
+when a Player-­hero is suffering from some limitation.
+When making an Ill-­favoured roll, players roll two Feat 
+dice instead of one, keeping the worst result among 
+the two.
+The sources of Ill-­favoured rolls are indicated in the included 
+Adventures.
+BONUS SUCCESS DICE
+It is possible for a Player-­hero to be attempting something under 
+favourable circumstances, or employing a particularly benefi-
+cial talent. When this happens, the Player-­hero may be granted 
+a bonus in the form of a number of additional Success Dice.
+Bonuses are indicated in the text as gain (1d) or more, 
+meaning that Player-­heroes add 1 Success die to those 
+they are entitled to roll.
+HOPE BONUS: A character’s Hope score is a pool of points 
+representing the reserve of spiritual vigour that heroes draw 
+from when confronted by difficult odds, or when a particu-
+larly good result is required by the circumstances.
+A Player-­hero about to make a die roll can spend 
+1 Hope point to gain (1d).
+Hope can be spent to gain dice on any roll made by a Player-­
+hero. It is not possible to spend multiple Hope points to gain 
+multiple bonus Success dice.
+INSPIRATION: Certain circumstances may result in a Player-­
+hero becoming temporarily Inspired. Inspired Player-­heroes 
+double the benefit of spending a Hope point:
+An Inspired Player-­hero who spends 1 Hope point to 
+get a Hope bonus gains (2d), instead of (1d).
+PENALTY SUCCESS DICE
+Player-­heroes wish they were lucky enough to enjoy only 
+favourable circumstances… At times, fortune seems to con-
+spire against them, they may put themselves in danger by their 
+own volition looking for a greater benefit, or they may have 
+FAVOURED VS ILL-­FAVOURED
+It is possible for a roll to be both Favoured and 
+Ill-­favoured for different, conflicting reasons — 
+when this happens, the roll is resolved normally 
+(roll one Feat Die only), even if multiple sources 
+would make a roll Favoured and only one would 
+make it Ill-­favoured (or vice versa).
+ILL-­FAVOURED PLAYER-­HEROES: At times, an 
+ability of an adversary or another special rule may 
+directly make a Player-­hero Ill-­favoured, instead 
+of specifying a particular roll — when this happens, 
+the unlucky adventurer is considered Ill-­favoured 
+on all rolls. For example, Player-­heroes who have 
+spent all their Hope points are considered to be 
+Ill-­favoured on all rolls.
+James Smith (Order #47812382)
+
+Prologue
+11
+fallen victim to some malicious power or spell. When this 
+happens, a Player-­hero may suffer from a penalty.
+Penalties are normally indicated in the text as lose (1d) 
+or more, meaning that a Player-­hero rolls fewer Suc-
+cess dice (down to a minimum of zero Success dice).
+conditions
+Die rolls can be modified by two special conditions that can 
+affect the Player-­heroes. Conditions are recorded on the char-
+acter sheet by checking the corresponding box.
+WEARY
+The resistance of the Player-­heroes is represented in game 
+terms by their Endurance score. Heroes can lose Endurance 
+in many ways, when their Endurance drops to a level equal to 
+or lower than their Load score, they become Weary.
+When a Weary hero is making a roll, all the Success 
+Dice that come up showing a result in an outlined 
+number (1, 2, or 3) are considered to have given a 
+result of zero instead.
+(See page 23 for more about the effects of losing Endurance 
+and Load).
+WOUNDED
+Serious injuries can cause a hero to become Wounded. While 
+losing and recovering Endurance is an everyday occurrence, 
+being Wounded is a more serious predicament for an adven-
+turer and will affect them for much longer.
+Wounded heroes who remain active risk being 
+knocked out of combat and recover lost Endurance 
+points more slowly (see Resting, page 18).
+DIE ROLL RESULTS
+FEAT DIE
+RESULT
+SPECIAL
+1–10
+Read number 
+normally
+—
+Success, regard-
+less of TN
+—
+Counts as a zero
+—
+SUCCESS 
+DICE
+RESULT
+SPECIAL
+1–3
+Read number 
+normally
+If Weary: counts as a 0
+4–5
+Read number 
+normally
+—
+Read number 
+normally
+On a successful roll, 
+getting one or more 
+ 
+indicates a higher quality 
+of success
+detailed die roll procedure
+Once the necessity of a roll has been determined, follow the 
+steps below to do it.
+1.	 Define what the Player-­hero is trying to achieve with 
+the roll. This is important to determine its conse-
+quences, both in the case of success and failure.
+2.	 Select the ability to be used for the roll. Players are 
+encouraged to suggest the appropriate ability. The 
+difficulty for the action is based on the relevant Attri-
+bute TN.
+3.	 Take one Feat Die and a number of Success Dice equal 
+to the rating of the chosen ability (or two Feat Dice, if 
+the roll is Favoured or Ill-­favoured). Spend 1 Hope to 
+gain (1d) — gain (2d) if Inspired.
+4.	Gain or lose dice according to any bonuses or penalties 
+that applies to the roll.
+5.	 Make the roll. If the roll is Favoured, choose the best 
+result on the Feat Dice, or the worst if Ill-­Favoured. If 
+you roll a , the action is automatically a success.
+6.	 Otherwise, all numerical dice results are added up to 
+get the action result. If you are Weary, all Success Dice 
+results in outline (1, 2 and 3) are ignored. If the total 
+action result is equal or superior to the relevant Target 
+Number, the action is a success. If the result is lower 
+than the Target Number, the action has failed.
+7.	 If the action is successful, the number of  results 
+rolled indicates the degree of success.
+BONUSES VS PENALTIES
+Bonuses and penalties are cumulative — if a 
+Player-­hero gains or loses dice from multi-
+ple sources, simply add up all gained dice and 
+subtract all lost dice. For example, if a Player-­
+hero gains (1d) from one source, gains (2d) 
+from another and loses (1d) from a penalty, the 
+affected roll gains a final (2d).
+James Smith (Order #47812382)
+
+THE RULES
+12
+ll Player-­heroes are defined in the game by a collec-
+tion of traits and numbers, describing their physi-
+cal, spiritual, and mental attributes, and the extent 
+of their knowledge and capabilities. These values 
+influence how they interact with the game rules.
+All characters included in this Starter Set have a 
+separate character sheet, a descriptive, double-­sided form — 
+the front of the sheet contains all the information stats and 
+the special traits of the character, while the back contains a 
+quick description of their background and personality.
+attributes
+There are three Attributes in the game: STRENGTH, HEART, 
+and WITS. These scores describe a hero’s fundamental phys-
+ical, emotional, and mental capabilities:
+	
+♦A Player-­hero with a high STRENGTH score can be 
+tough and fit, or quick and alert, or physically attrac-
+tive or imposing. Every aspect of an adventurer that 
+relies on vigour or physical well-­being is represented 
+in the game by STRENGTH.
+	
+♦
+HEART measures an adventurer’s capacity for emo-
+tion, empathy, and enthusiasm. A Player-­hero with a 
+high HEART score can be fiery, energetic, and hard 
+to daunt. Activities that benefit from a passionate or 
+dynamic temper may be influenced by a Player-­hero’s 
+HEART score.
+	
+♦A Player-­hero with a high WITS rating can be clever, 
+attentive, and ingenious. Any action that calls for an 
+adventurer to be sharp-­witted, sensible, or wise, bene-
+fits from a Player-­hero’s WITS score.
+target numbers
+The three Attribute ratings are used to determine a Player-­
+hero’s standard TNs — the default difficulty levels of all rolls 
+made to challenge the characteristics of a hero.
+	
+♦The STRENGTH TN is used in conjunction with all 
+STRENGTH Skills, and when resolving attack rolls.
+	
+♦The HEART TN is used in conjunction with all HEART 
+Skills and when making VALOUR rolls, for example to 
+resist the effects of fear.
+	
+♦The WITS TN is used in conjunction with all WITS 
+Skills and when making rolls of WISDOM, for example 
+to resist the temptation of treasure.
+CHARACTERISTICS
+“… you have been chosen, and you must therefore use 
+such strength and heart and wits as you have.”
+James Smith (Order #47812382)
+
+Characteristics
+13
+distinctive features
+Distinctive Features describe aspects of an adventurer’s 
+build or temper, personality traits or physical peculiarities. 
+These features help players to picture their characters, and 
+encourage deeper roleplaying. Players are invited to take 
+into account their heroes’ Distinctive Features throughout 
+the game and to use them as guidelines, in particular when 
+choosing a course of action for their adventurers.
+Additionally, players can invoke a Distinctive Feature 
+to improve their chances to succeed at a roll using a 
+Skill. When this happens, the Player-­hero is consid-
+ered to be Inspired.
+A Distinctive Feature can be invoked on a roll only if, based 
+on its description, it is reasonably plausible for someone with 
+that quality to fare better than an individual without it.
+skills
+Almost every action that heroes can attempt in the game is 
+resolved using a Skill: whether a Player-­hero is walking across 
+the length of the Shire to get back home (TRAVEL), running 
+away from a threat (ATHLETICS), or listening intently to an 
+orator’s speech to weigh their words (INSIGHT).
+In game terms, Skills represent what Player-­heroes 
+are able to do and how good they are at doing it. The 
+rating of a hero in a particular Skill is indicated by 
+the number of filled-­in diamond-­shaped boxes to the 
+right of its name — the higher the number of dia-
+monds, the better!
+Skills and their use are described starting on page 14.
+FAVOURED SKILLS
+A number of Skills are marked as Favoured (the box to the 
+left of their name is checked). Favoured Skills highlight those 
+abilities that come most naturally to a Player-­hero.
+All rolls made using a Favoured Skill are Favoured rolls.
+SKILL CATEGORIES
+Each Skill belongs to one of three categories, based on which 
+Attribute TN it’s rolled against. For ease of reference, the 
+Skills are organised on a character sheet in three columns 
+placed right under the Attribute box they depend on.
+	
+♦
+STRENGTH SKILLS: The Skills in this category rely on 
+the Player-­hero’s physical aptitude. An adventurer with 
+a high Strength score is more likely to be imposing 
+(AWE), to have a clear singing voice (SONG), to be fit 
+and agile (ATHLETICS), to have good sight and hear-
+ing (AWARENESS, HUNTING), and to possess skilful 
+hands (CRAFT).
+	
+♦
+HEART SKILLS: The Skills in this category depend 
+on the Player-­hero’s force of spirit. An adventurer 
+with a high Heart score may be a charismatic leader 
+(ENHEARTEN, BATTLE), an energetic guide (TRAVEL), 
+a gracious gentleman (COURTESY), be able to read 
+the hearts of others (INSIGHT), or to understand their 
+hurt and how to heal them (HEALING).
+	
+♦
+WITS SKILLS: The Skills in this category depend on the 
+Player-­hero’s mental aptitude. A hero with a high Wits 
+value will quickly learn witty oratory (PERSUADE), the 
+arts of a burglar (STEALTH), show attentiveness (SCAN, 
+EXPLORE), and will be clever and studious (RIDDLE, 
+LORE).
+combat proficiencies
+Combat Proficiencies express how well Player-­heroes conduct 
+themselves when engaged in battle. Rolls made using Combat 
+Proficiencies are resolved in the same way as Skill rolls, rolling 
+a Feat Die and a number of Success Dice equal to the rank 
+possessed in the Combat Proficiency used — rolling only a 
+Feat die with rank 0.
+Combat Proficiencies are rolled against the STRENGTH 
+TN when making Attack rolls (see Combat, page 22).
+The various Combat Proficiencies are presented starting on 
+page 17.
+endurance, hope and parry
+These additional stats are connected to a hero’s main Attri-
+bute scores. Endurance and Hope are the fundamental 
+resources that keep an adventurer going — Endurance points 
+are lost while engaging in strenuous activities, Hope points 
+are spent voluntarily by players when their Player-­heroes try 
+to overcome their limits. The Parry score sets the Target Num-
+ber for all attack rolls targeting a Player-­hero.
+More information on how Endurance and Hope work is 
+found on page 18. Parry is explained in the Combat chapter, 
+starting on page 22.
+James Smith (Order #47812382)
+
+THE RULES
+14
+skills
+“There is food in the wild,” said Strider; “berry, root, and herb;  
+and I have some skill as a hunter at need.”
+The 18 Skills cover wide areas of knowledge and ability, 
+enabling players and the Lore­master to resolve most situa-
+tions encountered during play.
+The following list presents them in alphabetical order. 
+A brief description is provided, to help identify the actions 
+that can be accomplished using each Skill.
+ATHLETICS
+ATHLETICS is a broad Skill, covering most physical activities 
+including; running, leaping, climbing, and swimming.
+AWARENESS
+The AWARENESS Skill represents a hero’s readiness to react and 
+the ability to notice something unexpected, out of the ordi-
+nary, or hard to detect. A high Skill score reflects both keen 
+senses and the experience to understand what is seen or heard.
+AWE
+This Skill measures the capacity to evoke respect in onlook-
+ers, and determines the impression the Player-­heroes make 
+on someone they meet for the first time. It can be used to 
+instil wonderment, admiration, or even fear. AWE arises from 
+a hero’s native charisma, but can also be engineered by a 
+dramatic entrance or impressive attire.
+BATTLE
+A rating in this Skill shows a firm grasp of the rules of battle 
+and the capability to maneuver appropriately when involved 
+in a violent confrontation. The BATTLE Skill can be used 
+to gain an advantage when fighting against a group of foes.
+COURTESY
+The Free Peoples recognise common norms of decency and 
+ancient conventions of behaviour. Observing them demon-
+strates respect and is a way of quickly establishing a friendly 
+footing even with strangers.
+CRAFT
+The CRAFT Skill doesn’t really cover the whole range of abili-
+ties of smiths, wrights, and other artisans, but reflects a talent 
+for making or mending things by hand. CRAFT can be used to 
+repair the wheel of a cart, or construct an improvised raft with 
+wood found on a river shore, or to start a fire on a windy hill.
+ENHEARTEN
+Player-­heroes can use the ENHEARTEN Skill to instil posi-
+tive feelings in others, urging them to act on the matter at 
+hand. They achieve this mainly through example, charisma, 
+and personal conviction, rather than through the effective 
+use of words (which falls under PERSUADE). This Skill can 
+be used on individuals, but is particularly effective in influ-
+encing crowds.
+EXPLORE
+Player-­heroes rely on the EXPLORE Skill when they move 
+through an unfamiliar area of the Wild. An EXPLORE 
+roll may be required during a journey to find out where 
+the Company is heading, or to get back on track after a 
+detour; to cope with adverse natural hazards; to create paths 
+through the wilderness or to choose a suitable place to set 
+up camp.
+HEALING
+The knowledge of how to relieve pain and apply remedies to 
+restore health to the suffering is an ancient one, and treat-
+ments differ from culture to culture. However, almost all tra-
+ditions agree on the treatment of serious injuries, which must 
+be tended immediately to keep from worsening.
+The HEALING Skill includes bone setting and the use of 
+herbs or salves.
+HUNTING
+Knowing how to hunt is a fundamental skill, shared by most 
+cultures of Middle-­earth. A HUNTING roll may be required 
+when pursuing a creature through wild areas, or to follow 
+tracks and identify a quarry by its spoor. The HUNTING Skill 
+also covers preparing traps and the training and use of hunt-
+ing dogs or birds.
+INSIGHT
+INSIGHT represents the ability to see beyond appearances 
+and to recognise the hidden thoughts and beliefs of people. 
+INSIGHT does not reveal if someone is lying, but the infor-
+mation it yields can be used to draw useful conclusions about 
+people’s motives.
+James Smith (Order #47812382)
+
+Characteristics
+15
+LORE
+LORE expresses a love for learning: be it a fascination with 
+descriptions of distant lands or an interest in family geneal-
+ogy. Whenever an action involves knowledge of some kind, 
+a LORE test is required.
+Player-­heroes are considered to be knowledgeable in the 
+traditions of their own people, and so the Lore­master should 
+rarely require a player to make a roll for information regard-
+ing them.
+PERSUADE
+This Skill allows the Player-­heroes to apply their reasoning to 
+convince other individuals of an idea or course of action. It 
+can be used to influence small groups of listeners, but only if 
+used in an appropriate context, such as a common hall. Per-
+suasion requires more time than other Personality Skills, but 
+can have a more lasting impact on other characters’ actions.
+RIDDLE
+Owing its name to the ancient game, the RIDDLE Skill rep-
+resents the ability to draw conclusions from seemingly uncon-
+nected scraps of information by deduction, reasoning, and 
+intuition. Adventurers also rely on RIDDLE whenever they are 
+forced to talk about a subject but prefer to conceal part of 
+what they know; for example, to tell something about them-
+selves without revealing their identity.
+As an accepted custom among many cultures, speaking 
+in riddles is usually allowed among strangers meeting for the 
+first time and wanting to speak guardedly. This Skill is also 
+used to gain helpful insight from a spoken or written riddle.
+SCAN
+Player-­heroes can use the SCAN Skill when examining some-
+thing closely or attentively. This Skill allows a Player-­hero to 
+skim through a book to locate a piece of relevant information, 
+look for concealed doors or hidden inscriptions, recognise a 
+familiar face in a crowd, or locate a set of tracks on the ground. 
+SCAN rolls are generally initiated by the players rather than 
+the Lore­master. One roll is required for each inspection of 
+a small area, such as a room. AWARENESS, rather than SCAN, 
+is used to see if a hero passively notices something.
+SONG
+Hobbits and Men, Elves and Dwarves, even Goblins and 
+maybe Orcs: all creatures of Middle-­earth celebrate by playing 
+music and singing songs. Great deeds and grim misfortunes 
+are remembered in verse, and pleasant or comic stories are 
+told to ease spirits and find comfort.
+The SONG Skill is used to recite poems, sing songs, or 
+play instruments suitable to a character’s Culture. It can also 
+be used to learn new works or create original compositions.
+STEALTH
+Player-­heroes resort to STEALTH whenever they need to act in a 
+furtive or secret way. The Skill includes hiding, moving 
+quietly, and shadowing others. These activities often 
+rely on quickness and precision, so a stealthy 
+Player-­hero combines practised caution with 
+the ability to judge the right moment to 
+take a chance.
+TRAVEL
+In the Third Age, the cities, 
+villages, and towns of Middle-­
+earth are often separated 
+by many leagues of wild 
+or deserted areas. A roll 
+of TRAVEL may let a 
+Player-hero estimate the 
+length of a journey, 
+read a map or evalu-
+ate whether a stranger 
+on the road can be 
+approached safely.
+James Smith (Order #47812382)
+
+THE RULES
+16
+James Smith (Order #47812382)
+
+Characteristics
+17
+combat proficiencies
+Legolas shot two through the throat. Gimli hewed the legs from under another 
+that had sprung up on Balin’s tomb. Boromir and Aragorn slew many.
+There are four different Combat Proficiencies in The One 
+Ring: AXES, BOWS, SPEARS, and SWORDS. Each one represents 
+a level of familiarity with a number of weapons of similar kind, 
+allowing a Player-­hero to attack using any weapon covered by 
+that specific Proficiency.
+The characteristics of all war gear carried by the Pre­
+generated Heroes are detailed on their character sheets, or 
+on the illustrated Item Cards included in the Starter Set.
+AXES
+Axes and other bashing weapons are often preferred to swords 
+by warriors who favour a more brutal approach to fighting. 
+Historically, the axe is the weapon of choice for most Dwarves, 
+and for their folk it surpasses the sword in both nobility and 
+respect. Dwarven weaponsmiths apply their cunning to mak-
+ing axes of many different shapes and uses, and from metals 
+of various colours.
+The AXES Combat Proficiency allows a Player-­hero 
+to use an axe, a great axe, a long-­hafted axe, but also 
+a mattock.
+BOWS
+A traditional hunting weapon, the bow is also commonly used 
+in warfare. Made from a single piece of wood, or from a com-
+position of wood, horn, or even metal, bows are a versatile 
+weapon. They can be used during sieges, from horseback, in 
+dense woodland, or in the open field. Archers usually carry 
+another weapon to draw when the enemy gets closer; they sel-
+dom carry shields, as they can’t use them when shooting a bow.
+The BOWS Combat Proficiency enables a Player-­hero 
+to make ranged attacks using a bow or a great bow.
+SPEARS
+The spear is arguably the most widespread weapon across 
+Middle-­earth, arming kings and soldiers, riders and infantry. 
+It is often no more than a long wooden shaft, tipped by a 
+leaf-­shaped metal head, but some spears are works of majes-
+tic artisanship, valuable heirlooms of noble households. The 
+length of a spear varies according to the use it is designed 
+for. Spears can be wielded one or two-­handed to thrust and 
+lunge, cast to pierce from a distance, or used from horseback 
+as lances. Warriors equipped with a spear typically use it in 
+conjunction with a shield, and they usually carry an additional 
+weapon, such as a sword or axe.
+The SPEARS Combat Proficiency allows a hero to make 
+ranged and close combat attacks using a short spear or 
+a spear, or to fight in close combat using a great spear.
+SWORDS
+The sword with a straight blade has always been the weapon 
+of choice among free Men and Elves. A mark of nobility or 
+rank, swords of superior make are passed down by generations 
+of warriors, and arms of ancient lineage are often imbued 
+with spells and curses, the bane of the servants of the Shadow. 
+Swords vary in size, shape, and quality as diverse as the folks 
+that craft them. Many malevolent creatures have devised 
+swords after their own fashion, usually crude counterfeits of 
+those made by Men and Elves.
+The SWORDS Combat Proficiency enables a Player-­
+hero to attack in close combat using short swords, swords, 
+and long swords.
+BRAWLING ATTACKS
+Adventurers who must leave behind their trusted 
+weapons may find themselves forced to fight 
+unarmed, or to rely on a simple dagger, or even 
+a thrown stone. When this happens, they rely on 
+their martial training to save themselves.
+	
+♦
+Player-­heroes performing an attack while 
+unarmed, or using an improvised weapon, 
+roll a number of dice equal to their highest 
+Combat Proficiency, but lose (1d).
+	
+♦
+Unarmed attacks have a Damage rating of 1, 
+and cannot cause a Piercing Blow (see Com-
+bat, page 23).
+James Smith (Order #47812382)
+
+THE RULES
+18
+endurance and hope
+Health and hope grew strong in them, and they were content with each good day 
+as it came, taking pleasure in every meal, and in every word and song.
+Endurance and Hope are what keep the Player-­heroes on the 
+road, providing them with reserves of energy and with that 
+additional momentum that sometimes is the only chance a 
+hero has to prevail.
+During play, heroes lose Endurance points as the result 
+of exertion and of suffering harm, and they spend Hope 
+voluntarily when they must succeed against difficult odds.
+The maximum Endurance and Hope values of the characters 
+are shown on their character sheets, while the Current Endur-
+ance and Current Hope boxes are used to keep track of any 
+changes that occur during play (alternatively, players can track 
+them using different coloured counters, dice or glass beads).
+endurance
+Endurance represents a Player-­hero’s resistance and is taken into 
+account whenever an adventurer is subjected to some form of 
+harm. In particular, Player-­heroes lose Endurance during com-
+bat, when they suffer physical damage from any other source, 
+or as a consequence of any strenuous task requiring great effort.
+Player-­heroes whose Endurance is reduced to zero drop 
+unconscious, and wake up after one hour with 1 Endur-
+ance point (unless they are also Wounded, see Resting).
+WEARY
+Used in conjunction with a hero’s carried Load, Endurance 
+determines when the weight and bulk of any equipment starts 
+to affect a Player-­hero’s performance.
+Heroes become Weary if their Current Endurance 
+score becomes equal to or lower than their total Load.
+When this happens, check the Weary box on the character 
+sheet. Player-­heroes remain Weary until their Endurance 
+score rises above their Load again.
+RESTING
+Player-­heroes regain lost Endurance points by resting. The 
+extent of the Player-­heroes’ recovery depends on whether 
+they take a short rest, or a prolonged one.
+SHORT REST: Under most circumstances, a day of adventur-
+ing allows for a maximum of one short rest, usually in the 
+middle of the day. If a precise timing account is desired, a 
+short rest may be said to correspond to at least one hour of 
+inactivity.
+With a short rest, adventurers recover a number of lost 
+Endurance points equal to their STRENGTH (Wounded 
+heroes do not recover any points at all).
+PROLONGED REST: Under normal circumstances, the group 
+of Player-­heroes is allowed to take a single Prolonged Rest 
+each day, (usually, a night’s sleep). The Lore­master may allow 
+the group to take more than one Prolonged Rest if the Player-­
+heroes are recovering in a safe and comfortable place.
+Player-­heroes taking a prolonged rest recover all lost 
+Endurance points (Wounded heroes recover a number 
+of points equal to their STRENGTH).
+hope
+Hope is a hero’s reserve of spiritual fortitude and positivity. 
+A hopeful character can keep going when physically stronger 
+heroes have already succumbed to despair.
+During play, players can spend Hope to gain a Hope 
+bonus on any die roll, or to trigger the effects of certain 
+Cultural Virtues.
+Player-­heroes whose Hope score is reduced to zero 
+are spiritually drained — it is impossible for them to 
+find the energy required to push themselves beyond 
+their limits.
+RECOVERING HOPE
+Recovering Hope points indicates that the Player-­heroes are 
+reaffirming their lost sense of confidence.
+	
+♦Player-­heroes who are down to zero Hope in the 
+course of an adventure recover a single point of Hope 
+once they take a Prolonged Rest.
+	
+♦All Player-­heroes recover a number of Hope points 
+equal to their HEART score between adventures.
+James Smith (Order #47812382)
+
+Characteristics
+19
+valour and wisdom
+“There is more in you of good than you know, child of the kindly West.  
+Some courage and some wisdom, blended in measure.”
+The heroic stature of an adventurer can be measured in dif-
+ferent ways. The One Ring uses two gauges to show this: WIS-
+DOM and VALOUR.
+WISDOM expresses the Player-­heroes’ trust in their own 
+capabilities, their self-­confidence and capacity for good judge-
+ment. VALOUR is a measure of a hero’s courage, as tempered 
+by dangerous deeds. Individuals of valour are willing to place 
+themselves in danger for the safety of others.
+The Lore­master may require the Player-­heroes to make 
+a roll, testing their WISDOM or VALOUR.
+When this happens, such rolls are resolved as usual, 
+rolling one Feat Die and a number of Success Dice 
+equal to the appropriate rating in the challenged abil-
+ity — The difficulty is the HEART TN for rolls based on 
+VALOUR, and the WITS TN for rolls based on WISDOM.
+rewards
+Rewards represent the characteristics of such high-­quality 
+weapons and defensive gear, priceless instruments of war 
+given to heroes by their own folk or family, or by generous 
+lords honouring them by letting them choose a weapon or a 
+suit of armour from their personal armoury.
+The Rewards earned by the Pregenerated Heroes are 
+fully explained on their character sheet.
+virtues
+Virtues are special abilities that complement a hero’s arsenal 
+of Skills and Combat Proficiencies, describing aptitudes that 
+come naturally to an adventurer, or that arise through time 
+and practice. Much more than simple talents, Virtues define 
+the heroic stature of the Player-­heroes.
+The Virtues practiced by the Pregenerated Heroes are 
+fully explained on their character sheet.
+useful items
+Any tool, instrument, or device carried by a Player-­hero to 
+perform one or more specific tasks is a useful item. Things 
+like a hammer, or a hunting knife, or flint and steel to start 
+a fire, and so on.
+Useful items are listed on a Player-­hero’s character sheet. 
+To determine if they gain a Player-­hero an advantage, they 
+are associated with a Skill.
+If a Player-­hero is making a roll outside of combat 
+using a Skill associated with a useful item, and the 
+Lore­master deems that this should grant the hero an 
+advantage, the Player-­hero gains (1d). Only one item 
+can benefit the same die roll.
+James Smith (Order #47812382)
+
+THE RULES
+20
+ADVENTURING
+Even the good plans of wise wizards like Gandalf and of 
+good friends like Elrond go astray sometimes when you are 
+off on dangerous adventures over the Edge of the Wild…
+he One Ring is played as a series of sessions, com-
+parable to the episodes of an ongoing tv show; 
+usually, two or three sessions are played as part of 
+a longer ‘story’, called an adventure. During each 
+session it is the job of the Lore­master to challenge the play-
+ers, putting them in difficult circumstances, setting fiendish 
+riddles for them to solve, and confronting them with formi-
+dable opponents.
+The gameplay is a dynamic narrative, as the players 
+take action to explore the situations they encounter. The 
+Lore­master then describes what happens as a result of their 
+actions, and the players again react to the new circumstances, 
+and so on.
+The Lore­master keeps the story flowing through a mix-
+ture of preparation and improvisation.
+how adventures work
+An average adventure should occupy the Lore­master and 
+the players for about two or three sessions of play, with each 
+session clocking in at around 3 hours of gaming.
+Generally speaking, every single session tends to follow 
+the same structure:
+1.	 Introduction
+2.	 Scenes
+3.	 End of the Session
+1. INTRODUCTION
+If the session is the first one of an adventure, the Lore­master 
+presents the current situation to the players. This usually sets 
+a date or time of the year (when), a location (where), and 
+defines an introductory situation (what) that includes infor-
+mation that allows for the involvement of the Company (why).
+If it’s not the first session of play, then the opening scene 
+picks up from where the adventure broke off at the end of 
+the previous session.
+THE ADVENTURES
+The five, ready-­to-­play scenarios presented in The 
+Adventures have been created expressly for this 
+publication. They are potentially playable using 
+the full rules for The One Ring, but they have been 
+written specifically with the participation of the 
+Pregenerated characters in mind. This notwith-
+standing, the guidelines presented in this chapter 
+may still prove useful to a Lore­master intending 
+to play them.
+James Smith (Order #47812382)
+
+Adventuring
+21
+2. SCENES
+Once a session has started, the gameplay transitions from 
+one scene to another, with each scene describing a situation 
+requiring the players to make meaningful decisions.
+Each scene can vary in duration from less than an 
+hour of play time (a short but meaningful encounter), 
+up to the entire length of the session (an important 
+gathering taking many hours of game time to be com-
+pleted). Between a number of main scenes and sec-
+ondary scenes, a session of play should not last more 
+than three or four hours.
+3. END OF A SESSION
+When the time allocated for the game session is up, the Lore­
+master and the players face two possible situations:
+	
+♦If the session ends without the players reaching a satis-
+factory conclusion, the gameplay will resume at a later 
+date with another session. When the playing group 
+meets again, the Lore­master starts by summarising 
+what happened in the previous one.
+	
+♦If, on the contrary, the current narrative arc has 
+reached its conclusion, the Lore­master draws the final 
+curtain on the gaming session. The adventure is over. 
+Time to plan for the next!
+James Smith (Order #47812382)
+
+THE RULES
+22
+combat
+There was a ring and clatter as the Company drew their swords.
+Even in a peaceful land like the Shire, combat may be the sad 
+but unavoidable culmination of a scene. Should a fight erupt, 
+the Lore­master and the players must follow the rules pre-
+sented in this section to make the fight a momentous event.
+Once a combat encounter is initiated, the following 
+steps must be applied in order to keep the action 
+flowing.
+opening volleys
+If the Player-­heroes and their opponents are separated by 
+a distance, at the start of a fight all combatants are allowed 
+to make ranged attacks before combat at close quarters is 
+initiated.
+The Lore­master must determine how many volleys to 
+allow, based on the distance separating the fighters — under 
+most circumstances, all combatants are entitled to at least 
+one volley using a bow or a thrown weapon. If the distance 
+is greater, then the Lore­master might allow combatants to 
+let loose two volleys, or even more.
+All volley attacks are resolved as normal ranged attacks 
+(see next page). Normally, the volley exchange is 
+resolved with the Player-­heroes launching their vol-
+leys first, unless the Lore­master considers the circum-
+stances to favour the opposition.
+When the opening volleys are completed, the combatants 
+cover the distance that separates them and begin fighting 
+at close quarters.
+close quarters rounds
+Once fighting at close quarters is initiated, the gameplay is 
+broken down into a cycle of rounds, played one after the 
+other until the end of the battle.
+Each round follows the sequence set out below:
+1.	 Stance: The Player-­heroes choose their stances.
+2.	 Engagement: All combatants in Close Combat are 
+paired with one or more opponents.
+3.	 Attack Rolls Resolution: The actions of all combat-
+ants are resolved, with those fighting in close combat 
+going first.
+1. STANCE
+All Player-­heroes select whether they will fight the round in 
+Close Combat, or Ranged Combat — Player-­heroes can choose 
+freely to fight in Close Combat at the start of each round, 
+while they are allowed to fight in Ranged Combat only if 
+there are at least two other adventurers fighting in Close 
+Combat.
+Fighters in Close Combat exchange blows in the thick 
+of the fight, using swords, axes and other close com-
+bat weapons, while those engaged in Ranged Com-
+bat stay back, using ranged weapons like bows or 
+spears, and can be targeted only by attackers using 
+similar weapons.
+2. ENGAGEMENT
+At the start of each round, Player-­heroes fighting in Close 
+Combat must choose one or more opponents to engage. 
+If all opponents are already engaged, Player-­heroes with-
+out an adversary must join another Player-­hero fighting 
+an enemy.
+Player-­heroes fighting in Ranged Combat cannot be 
+engaged in Close Combat, and can only be attacked by ene-
+mies using ranged weapons.
+STANCE CARDS
+This Starter Set box includes a set of stance cards 
+—these are meant to be used with The One Ring 
+core rulebook. The full rules for fighting and trav-
+elling allow the players to choose a more specific 
+stance during battles, and to assign a role to each 
+Player-­hero during a journey.
+Players wishing to use the Stance cards can still 
+do so, knowing that Forward, Open and Defensive 
+are all Close Combat stances, and that Rearward 
+is the Ranged Combat stance.
+James Smith (Order #47812382)
+
+Adventuring
+23
+3. ATTACK ROLLS RESOLUTION
+Unless differently specified, the attacks of all combatants are 
+resolved with the Player-­heroes going first. When all Player-­
+heroes have resolved their attacks, the Lore­master will resolve 
+those of their adversaries. Close Combat attack rolls are 
+resolved first, then all Ranged Attack rolls follow.
+An attack is a die roll made using the Combat Proficiency 
+corresponding to the weapon used.
+	
+♦The difficulty of all attack rolls by the Player-­heroes is 
+based on their STRENGTH TN, modified by the Parry 
+rating of the targeted enemy.
+	
+♦The difficulty of all attack rolls made by adversaries 
+against Player-­heroes are equal to the target hero’s 
+Parry score instead.
+A successful attack roll inflicts damage in the form of an 
+Endurance Loss based on the weapon used, and may inflict 
+additional Special Damage types based on the Degree of Suc-
+cess of the roll. Finally, attacks may cause more long-­lasting 
+injuries if a Piercing Blow is scored.
+MORE ENEMIES THAN HEROES
+If there are more enemies than heroes, it is 
+possible that there will be enemies left when 
+everyone fighting in Close Combat has engaged 
+an adversary. If this happens, the Lore­master 
+chooses whether the ‘spare’ enemies engage a 
+Player-­hero who is already fighting in a Close 
+Combat stance, or stand back to attack with a 
+ranged weapon. Enemies who stand back to use 
+a ranged weapon may attack any Player-­hero 
+involved in the fight.
+ENDURANCE LOSS
+When a melee or ranged attack roll succeeds, the target suf-
+fers an immediate loss of Endurance equal to the Damage 
+rating of the weapon used.
+	
+♦Player-­heroes who see their Endurance decrease to 
+match or go below their total Load score become 
+Weary; if their Endurance is reduced to zero, they 
+drop unconscious instead.
+	
+♦Adversaries do not normally become Weary due to 
+Endurance loss, but are normally eliminated upon 
+reaching zero Endurance.
+SPECIAL DAMAGE
+If a successful attack roll produces one or more Success icons 
+( ), they can be used to trigger one or more special results. 
+Each heading below indicates how many Success icons are 
+required to trigger the corresponding effect. Multiple Suc-
+cess icons can be used to trigger different results, or the same 
+one multiple times.
+	
+♦
+HEAVY BLOW — ANY WEAPON (
+): You have hit your 
+opponent with great force and precision — Spend 1 
+Success icon to inflict to your target an additional loss of 
+Endurance equal to your STRENGTH rating (adversaries use 
+their Attribute Level instead).
+	
+♦
+FEND OFF — ANY CLOSE COMBAT WEAPON (
+): You 
+exploit your successful attack to place yourself in an 
+advantageous position — Spend 1 Success icon to gain a 
+Parry modifier of +2 against the next attack aimed at you.
+	
+♦
+PIERCE — BOWS AND SPEARS (
+), SWORDS (
+): You 
+have hit a less-­protected part of the adversary’s body 
+— Spend 1 Success icon to modify a Feat die numerical result 
+of your attack by +2, thus possibly triggering a Piercing Blow 
+(
+ and 
+ results are unaffected).
+PIERCING BLOWS
+In addition to causing the loss of Endurance points, any 
+success­ful attack may inflict a Piercing Blow.
+An attack roll produces a Piercing Blow on a 10 or  
+result on the Feat Die.
+Characters hit by a Piercing Blow must immediately roll one 
+Feat Die, plus a number of Success Dice equal to the PRO-
+TECTION value of the armour worn (a PROTECTION Test).
+The Target Number for the roll is equal to the Injury 
+rating of the weapon used by the attacker. If the roll 
+fails, then the target of the attack has received a life-­
+threatening blow — a Wound (see below).
+James Smith (Order #47812382)
+
+THE RULES
+24
+WOUNDS
+Most adversaries are killed outright when Wounded (unless 
+specified differently in their description). Player-­heroes, on 
+the other hand, can resist being Wounded once without seri-
+ous consequences, but risk more if injured a second time.
+When Player-­heroes are Wounded for the first time 
+they check the Wounded box on their character sheet.
+As seen under Endurance on page 18, Player-­heroes whose 
+Wounded box is checked recover Endurance slowly.
+Player-­heroes who are wounded a second time (they 
+receive a Wound when their Wounded box was already 
+checked) see their Endurance drop to zero, and they 
+fall unconscious. This second Wound is not recorded 
+on the character sheet.
+Player-­heroes recover from their injuries between adventures, 
+or in a week. They are allowed to reduce the severity of their 
+Wound with a HEALING roll:
+A successful HEALING roll reduces the time required 
+to recover by 1 day, plus 1 day for each  icon scored 
+(to a minimum of 1 day).
+Each hero may be administered a successful HEALING roll 
+only once. A failed roll cannot be repeated until at least a 
+day has passed, as the failure of the treatment isn’t immedi-
+ately apparent.
+SERIOUS INJURIES AND DEATH
+The rules about injuries as detailed in this Starter 
+Set are meant to evoke a mood that is more 
+appropriate to stories as those presented in The 
+Adventures — adventuring in the Shire is meant 
+to be exciting, maybe thrilling, but never life-­
+threatening. ­Hobbit adventurers and their like 
+are meant to return home with an exciting tale 
+to tell to their many relations, not to be mourned 
+after their demise.
+OTHER ACTIONS THAN ATTACKS
+Players may propose to do something different from 
+an attack roll, something unusual or unexpected (this 
+is usually a sign that they are enjoying the game, and 
+the Lore­master should encourage it wherever possible).
+The factors to consider when resolving actions other 
+than the attack rolls are time, difficulty, and consequences.
+	
+♦Can you perform the action in one round, or will it 
+take more time? The Lore­master must decide, but 
+for such cases consider a round to last a maximum of 
+30 seconds.
+	
+♦
+Does the action require a die roll? If so, success or 
+failure must have clear consequences. Generally, if 
+succeeding at an action will grant an advantage to 
+the Player-­heroes, a failure should cause a disadvan-
+tage of equal importance.
+TALKING WITH THE ENEMY
+Often, the Company faces creatures capable of speech. 
+Orcs and the most intelligent among Trolls speak a 
+debased version of the Common Tongue, for example, 
+and Dragons can outwit in conversation the smartest 
+adventurer. This means that violence need not be the 
+only way to survive a combat…
+Some good roleplaying and clever thinking might 
+allow the Player-­heroes to find a way out of a dangerous 
+situation, for example, tricking an excessively powerful 
+enemy into thinking that the heroes are much stronger 
+than they really are, or by outright deceiving them. Think 
+of Gandalf tricking the Stone-­Trolls, or Bilbo challeng-
+ing Gollum at the Riddle Game, and then entertaining 
+Smaug with a clever conversation. But a wicked Lore­
+master should remember that the opposite is also pos-
+sible — a cunning adversary might find a way to trick the 
+Player-­heroes and lure them into a trap, or put them in a 
+disadvantageous position using only words.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)

--- a/static/text/the-one-ring/the-one-ring-starter-shire.txt
+++ b/static/text/the-one-ring/the-one-ring-starter-shire.txt
@@ -1,0 +1,3263 @@
+the shire
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+LEAD WRITER
+James Michael Spahn
+ADDITIONAL WRITING
+Francesco Nepitello
+GAME DESIGNERS
+Francesco Nepitello and Marco Maggi
+ADDITIONAL RULES DEVELOPMENT
+Michele Garbuggio
+CONCEPT ART
+Alvaro Tapia
+COVER ART
+Martin Grip
+OTHER ART
+Alvaro Tapia, Martin Grip, Jan Pospíšil, Niklas Brandt, Henrik Rosenborg,  
+Antonio De Luca, Federica Costantini, Melissa Spandri, Giuditta Betti
+GRAPHIC DESIGN
+Christian Granath, Dan Algstrand, Niklas Brandt
+MAPS
+Francesco Mattioli
+EDITORS
+John Marron, Jacob Rodgers
+PROJECT MANAGERS
+Martin Takaichi, Tomas Härenstam
+BRAND MANAGER
+Robert Hyde / Sophisticated Games
+EVENT MANAGER
+Anna Westerling
+PR MANAGER
+Boel Bermann
+STREAMING
+Doug Shute, Matthew Jowett
+ISBN
+978-91-89143-48-7
+SPECIAL THANKS TO
+Claudio Muraro and Umberto Pignatelli
+PLAYTESTING OF THE 2ND EDITION
+Adam Rawson, Agnes Rudbo, Amanda Stenback, Andreas Lundström, Anna Ave, Charlie Conley, Chiara Ave, 
+Dan Price, Daniel Raab, Dennis Detwiller, Francisca Hoogenboom, Giuliano Nepitello, Kathleen Kiker, 
+Kyle Wood, Lorenzo Perassi, Luca Donati, Maja Emilie Søgaard Widerberg, Maner Samuel, Marco Beltramino, 
+Michael Kiker, Michela Baù, Peter Bergman, Peter Link, Ric Wagner, Stephen Buck, Steven Nguyen Dinh, 
+Umberto Pignatelli, Vanessa Ratschinske.
+The One Ring, Middle-­earth, and The Lord of the Rings and the characters, items, events, and places therein  
+are trademarks or registered trademarks of the Saul Zaentz Company d/b/a Middle-­earth Enterprises (SZC)  
+and are used under license by Sophisticated Games Ltd. and their respective licensees. All rights reserved.
+James Smith (Order #47812382)
+
+THE SHIRE
+2
+a brief history of the shire
+Thus began the Shire-­reckoning, for the year of the crossing of the Brandy­wine (as the Hobbits 
+turned the name) became Year One of the Shire, and all later dates were reckoned from it.
+Though no one in the Shire recalls the time before they passed 
+over the Bridge of Stonebows, Hobbits did not spring wholly 
+into existence out of nothing. Ancient legends speak of a small, 
+stout, river-­folk that was driven out of the Anduin River valley 
+and made their way west. There are suggestions that during their 
+long, meandering journey, they spread into the North-­realm of 
+Men, perhaps making their way as far south as the region now 
+known as Dunland. Tales forgotten by most and often consid-
+ered unreliable claim that Hobbits once swore allegiance to that 
+ancient North Kingdom, and took part on at least one occa-
+sion in feats of arms when evil things came out of dark places.
+It was after taking up brief residence in the Chetwood and 
+the area surrounding the village of Bree that a company of 
+Hobbits petitioned the King of Men for a land of their own. 
+They were granted his leave to occupy an area of verdant 
+lands and build a realm for themselves that would ensure 
+a bountiful life, hopefully free of danger and woe. Led by 
+the brothers Marcho and Blanco, that company of Hobbits 
+crossed the Brandy­wine, claiming as their own domain the 
+land ranging from its banks to the Far Downs, some forty 
+leagues west. They named that realm and all the surrounding 
+land fifty leagues from north to south the Shire.
+Originally ordered to maintain the great East-­West Road 
+and the Brandy­wine Bridge as a service to the King, the Shire-­
+folk and their humble domain were soon left to their own 
+devices. Even the title of Thain, granted to a single Hobbit 
+of worth who spoke with the King’s authority, rapidly became 
+little more than an honorific among local residents. With 
+the passing of only a handful of decades, few recognised the 
+existence of the Shire to be of any importance. Few, except 
+the Hobbits, of course. Free to tend to their own affairs, the 
+denizens of the Shire prospered, and soon all the Hobbits 
+of the wide world took up residence within its borders (save 
+for those few still making their home in and around Bree).
+This first generation of Shire-­folk would suffer greatly at 
+the hands of the Great Plague less than forty years after the 
+foundation of the Shire (S.R. 36)*, but though the terrible 
+sickness caused the death of innumerable Hobbits and Men 
+alike, the resilience of the Shire proved to be greater than 
+that of the North Kingdom.
+The days of the King were finally over in the year 375. The Shire 
+became truly independent, though it mattered little to the 
+world beyond its borders (save as a curiosity to the most inquis-
+itive). Severed from larger history, Hobbits continued their 
+lives in peace and plenty for countless generations. Villages 
+and communities seemed to flourish endlessly, their precise 
+dates of appearance largely unrecorded in any local chronology.
+It is indeed due only to gossip and family history that we 
+know that the Oldbucks, who could trace their lineage back 
+to Bucca of the Marish, first Thain of the Shire, were so bold 
+as to cross the Brandy­wine River going east and establish the 
+community of Buckland, now home to Brandy Hall and the 
+* To those outside the Shire their method of reckoning the passage of time 
+may seem odd or even out of touch with the rest of Middle-­earth. Quite so. 
+Hobbits do not concern themselves with the affairs of Men or Elves, and it 
+was in the 1601st year of the Third Age that they began living according 
+to their own calendar. As such, outsiders can simply add 1600 to the Shire 
+Reckoning year to get its equivalent in the Third Age. —G
+REGARDING
+ 
+THE SHIRE
+At once the western Hobbits fell in love with their new land,  
+and they remained there, and soon passed once more 
+out of the history of Men and of Elves.
+James Smith (Order #47812382)
+
+A brief history of the Shire
+3
+great Brandybuck family. It was Brandy Hall’s founder Gor-
+hendad Oldbuck who changed his family name to Brandy-
+buck, in honour of his new community in the same year of 
+its founding, S.R. 740.
+It was during this same period of prosperity that Tobold 
+Hornblower would learn the art of the cultivation and smok-
+ing of pipe-­weed, an enduring art that remains almost unique 
+to the people of the Shire even unto this day. Isengrim Took 
+II would begin construction of the Great Smials in Tuckbor-
+ough in 1083, which still stands as the ancestral home of the 
+Took family. It is also likely that in this time the Messenger 
+Service (and later the Quick Post) were established to carry 
+news between the ever-­growing number of communities.
+No Hobbit knows what prompted Golfimbul and his Goblin 
+horde to descend from Mount Gram and cross the borders of 
+the North Farthing. Instead, everyone from Michel Delving 
+to Buckland knows that it was Bandobras “Bullroarer” Took 
+of Long-­Cleeve who led the Hobbitry-­in-­arms against the foul 
+invader in the spring of the year 1147. Standing well over four 
+feet tall and capable of riding a full-­grown horse, Bullroarer 
+Took charged screaming across the Greenfields and straight 
+into the Goblin lines. With a single swing of his mighty club, 
+he knocked the goblin warlord’s head right off his shoulders. 
+The head is said to have sailed straight over the entire enemy 
+army, eventually landing in a rabbit hole. So terrifying was this 
+sight that the entire invading force fled. Oh, and the game 
+of golf was invented in that very moment as well.
+But the history of the Shire is not without its less violent 
+troubles, and the first real threat to its existence came not from 
+Goblins, but from famine. The winter of 1158 saw the beginning 
+of the Long Winter. The ground froze hard and cold, with ice 
+that came in the early days of November and did not leave until 
+the last days of spring. Crops were destroyed by frost, and the 
+delay in the turning of the season left planting to be done late, if 
+indeed it could be done at all. The Days of Dearth that followed 
+claimed the lives of many Hobbits for a full year, and it was long 
+before joy and celebration returned to the Four Farthings. But 
+perhaps it was this difficult time that reminded Hobbits that 
+they were of hardy stock and strong hearts — for they endured.
+ Minor horrors continued to plague the Shire, culminating 
+in another terrible cold spell, known now as the Fell Winter of 
+1311. It was during this brutal season that the Brandy­wine River 
+froze over, and that dire White Wolves came down out of the 
+north and crossed into the East­farthing. On that terrible night 
+the Horn-­call of Buckland was sounded, and for the first time 
+in almost two centuries, Hobbits took up arms to defend their 
+own lands from invaders. Though victorious, the losses of that 
+battle were grievous, and combined with the famine from an 
+absent growing season, the people of the Shire suffered many 
+deaths. But hope often comes when unlooked for, and it was 
+in that time that Gandalf, the Grey Wizard, came to the aid of 
+James Smith (Order #47812382)
+
+THE SHIRE
+4
+many. It is believed by some that this kindness may have saved 
+the Shire all together, though few Hobbits living now would 
+make such a claim, considering that Gandalf is now seen as 
+quite the disturber of the peace (stories also abound concern-
+ing how Gandalf was helped by a group of Men, who returned 
+to the wilds when their task was completed).
+In the decades following those dark days, peace and com-
+fort became once again the rule in the Shire. The largest trou-
+ble to strike this green country in recent years was the disap-
+pearance and surprising return of Bilbo Baggins, of Bag End. 
+Once a respectable Hobbit, he went off on some adventure 
+with a troupe of Dwarves and the mischievous Wizard Gandalf, 
+only to return, nearly two decades ago now, astride a pony 
+laden with riches, according to rumour. Since that day, Bilbo 
+was officially considered ‘cracked’, and all sorts of trouble was 
+attributed to him: Dwarves started to be seen more often on 
+the great East-­West Road, and strange, hooded wanderers 
+were sighted by more than one bounder. And wouldn’t you 
+know it — since then that trouble maker Gandalf seems to 
+appear and disappear about the Shire whenever he pleases! 
+No doubt coaxing tweens and Tooks alike into all manner 
+of adventure as he did that poor, mad Baggins of Bag End.
+THE ART OF SMOKING
+The habit to smoke the herb known as pipe-­weed or leaf 
+using pipes of wood or clay is a peculiar art that is almost 
+certainly the invention of Hobbits. Adopted in recent 
+times by travelling Dwarves and wandering Wizards, it 
+is very popular among the inhabitants of Bree. Indeed, 
+the idea to put the leaf into pipes for smoking can almost 
+certainly be attributed to Bree-­Hobbits.
+The true mastery of that art began over two hun-
+dred years ago when Tobold Hornblower of Longbottom 
+grew, dried, and smoked his first crop of Longbottom 
+Leaf. Even to this day, though other flora can be smoked, 
+no Hobbit, nor Dwarf, nor Man can argue that Longbot-
+tom is not the finest smoke in Middle-­earth.
+It is likely that Tobold, being rarely one to travel, 
+brought the practice back into the Shire after one of his 
+rare trips to Bree, though he never gave details as to what 
+possessed him to bring the plant to the South­farthing 
+and cultivate it on the farmland he had claimed as his 
+own. Though the details of its arrival will remain forever 
+a mystery, Tobold was determined to grow this won-
+derful herb, and within a few generations it was found 
+in the many variants now known to flourish throughout 
+Longbottom and across the Shire.
+Pipe-­craft, like the art of smoking, is a matter of 
+pride for many Hobbits of Longbottom and the South­
+farthing, and their products range from stubby clay 
+pipes smoked by simple farmers to ornate and intricately 
+carved wooden pipes that are the treasured heirlooms of 
+many of the wealthy families across the Shire. Indeed, it 
+is not uncommon for several Hobbits to get together and 
+engage in impromptu contests seeing who can blow the 
+biggest smoke ring from one of these grand creations.
+BLOWING SMOKE RINGS
+Those who find themselves drawn into a smoke ring 
+blowing contest (which most often occur inside inns or 
+on summer nights in the South­farthing), may make a RID-
+DLE roll, for the art of smoking is a delicate and subtle 
+one. The character that achieves the highest quality of 
+success is declared the winner, and ties are common, as 
+Hobbits dispute the features of one ring or another in 
+the seconds before it disperses. Tradition holds that the 
+winner gives as a gift to those who have lost a pouch of 
+their finest tobacco, so that they might further study the 
+art. However, the winner is still held in high regard, and 
+can expect a filled tankard and a free meal at the losers’ 
+table within the next few days.
+James Smith (Order #47812382)
+
+A brief history of the Shire
+5
+the tale of years 
+of the shire
+Described below in brief are important events in the history 
+of the Shire, notating both the dates as they are recounted 
+in the calendar of the Shire Reckoning and the years of the 
+Third Age as recognised by those outside its borders.
+	
+♦1 S.R. / 1601 T.A. — Marcho and Blanco establish the 
+Shire in the lands between the Far Downs and the 
+Brandy­wine River, with the blessing of the King of the 
+North Kingdom.
+	
+♦
+36 S.R. / 1636 T.A. — The Great Plague sweeps across 
+the Shire and many Hobbits die of the pestilence.
+	
+♦
+375 S.R. / 1975 T.A. — A company of Hobbit archers 
+travels to aid the King. They never return. With the fall 
+of the North Kingdom the Shire effectively becomes 
+an independent realm.
+	
+♦
+740 S.R. / 2340 T.A. — Gorhendad Oldbuck abdicates 
+the Thainship of the Shire and travels east to establish 
+a new settlement on the far banks of the Brandy­wine 
+River, where he takes the family name of Brandybuck 
+and begins construction of Brandy Hall.
+	
+♦1070 S.R. / 2670 T.A. — Tobold Hornblower cultivates 
+the first recorded crop of pipe-­weed.
+	
+♦1083 S.R. / 2683 T.A. — Isengrim Took II begins excavat-
+ing the Great Smials, ancestral home of the Took family.
+	
+♦1147 S.R. / 2747 T.A. — The Battle of the Greenfields. 
+Bandobras “Bullroarer” Took defeats the Goblin horde 
+of Golfimbul and routs his invading army that had 
+come down from Mount Gram.
+	
+♦1158–1160 S.R. / 2758–2760 T.A. — The Long Winter. A 
+brutal winter destroys crops, and snow covers the Shire 
+from November through March. The famine, sickness, 
+and death that follow for over a year become known as 
+the Days of Dearth.
+	
+♦1311–1312 S.R./ 2911–2912 T.A. — The Fell Winter. A 
+long, hard winter freezes the Brandy­wine River solid. 
+White wolves cross its waters and are driven back by 
+Hobbit defenders after the Horn-­call of Buckland is 
+sounded. Famine again briefly grips the Shire through 
+the season, and into the spring. Gandalf the Grey 
+comes to the aid of the Hobbits, and saves many lives 
+with the help of mysterious wanderers.
+	
+♦1341 S.R. / 2941 T.A. — Bilbo Baggins of Bag End 
+departs the Shire in the company of Gandalf the Grey 
+and thirteen Dwarves.
+	
+♦1342 S.R. / 2942 T.A. — Bilbo Baggins returns from his 
+travels in foreign parts, proves he is very much alive, 
+and reclaims ownership of his home as it is being auc-
+tioned on the presumption of his death. He retires, 
+becoming a local oddity, and living off the wealth he 
+acquired in far off lands.
+	
+♦1357 S.R. / 2957 T.A. — Cotman Bunce resigns. Pott 
+Whitfoot elected Mayor of Michel Delving.
+	
+♦1360 S.R. / 2960 T.A. — Current year.
+THE HOBBITRY-­IN-­ARMS
+Among the notable organisations established within the 
+Shire are its oft-forgotten martial institutions. The first of 
+these is the Hobbitry-in-arms, which acts as a militia to 
+defend the Shire in times of dire need. It exists now as 
+little more than a ceremonial company overseen by the 
+Thain, who serves as its captain. 
+As to day-to-day matters, these are instead tended 
+to by the Watch. The Watch consists of twelve Shirriffs, 
+with three assigned to each of the four farthings, and 
+by a variable number of Bounders. Shirriffs are easily 
+identifiable by the single feather in their cap, and are led 
+by the First Shirriff — an honorific bestowed upon the 
+Mayor of Michel Delving. But little trouble occurs within 
+the borders of the Shire, and like the Hobbitry-in-arms, 
+being a Shirriff is little more than a ceremonial position in 
+all but the darkest of times. The most numerous element 
+of the Watch, and by far the busiest, is the Bounders, 
+tasked with ‘beating the bounds’ — that is, seeing that 
+outsiders and mischief makers don’t cross into the Shire. 
+Tasked with reporting any trouble they encounter to the 
+Shirriffs, what they do is little more than nosing about 
+the Shire, dipping into local inns to catch up on the most 
+recent gossip, chasing naughty Hobbit children from a 
+farmer’s crop, or helping retrieve the occasional way-
+ward cat from a tree. 
+In recent years, as Dwarves and other travellers have 
+begun to enter the Shire more and more, the job of the 
+Bounders has become a little livelier, much to their con-
+sternation. Some blame the coming of the Wizard Gan-
+dalf, while more than a few consider Bilbo Baggins to be 
+responsible for bringing ill-fortune to the Shire, along 
+with his piles of gold and jewels that he has stuffed away 
+in Bag End.
+James Smith (Order #47812382)
+
+THE SHIRE
+6
+families and culture
+Since the fall of the North King, the people of the Shire have 
+lived in their own way for generations. To outsiders, Hobbits 
+are seen as a simple or even backwards folk, with little con-
+cern for affairs that are not their own. While it is an absolute 
+certainty that the latter is a statement of fact, the former is a 
+falsehood perpetuated only by fools and the unwise.
+At first glance, a casual observer could claim that food 
+and drink are chief among a Hobbit’s concerns, and that 
+wouldn’t be too far off the mark. But the real centerpiece of 
+the life of each individual Hobbit, and the Shire as a whole, 
+is the family. Very nearly every Hobbit of the Shire can place 
+everyone they meet somewhere along their family line, from 
+second cousins twice removed to great-­great-­great grandpar-
+ents — and they can do so from memory.
+Hobbit families gossip and spat, argue and snipe, but 
+the bonds of kinship are never so far from their hearts that 
+they forget both where and whom they came from. No one 
+can help but be filled with great pride when recalling the 
+notable deeds of an ancestor, often as if those actions were 
+their own. Unfortunately, no one ever forgives any insult or 
+damage suffered either, if amends are not made, and petty 
+rivalries can last generations.
+This love of lineage means that more than a few person-
+alities are recorded forever in the collective memories of all 
+the people of the Shire, starting with the founders Marcho 
+and Blanco. Their names are known and celebrated by every 
+Shire-­Hobbit, even though their family affiliation has been 
+lost to time (it is the secret hope of every Hobbit patriarch 
+and matriarch to discover proof of a common heritage, and 
+attempts have been made by more than a few Tooks or Bran-
+dybucks over the years — to no appreciable results, so far). 
+Other notable ancestors include the unknown members of 
+the company of archers that centuries ago went north to aid 
+the King, never to return. While their family names are lost 
+like those of Marcho and Blanco, there is scarcely a man-
+telpiece in the North­farthing that doesn’t sport some rusty 
+knife blade, pitted arrow-­head, or rotting feathered cap held 
+as proof of kinship.
+The average Hobbit’s love for genealogical lore is not lim-
+ited to ancient history. It is indeed only thanks to this passion 
+that most Hobbits can orient themselves in the complex web 
+of relations between modern families like the Took, Baggins, 
+Brandybuck, Hornblower, Boffin, and Bolger — just to name 
+a few. As these families intermarried with one another, it did 
+not take long before a great many Hobbits were claiming kin-
+ship with folk from across the Shire who would otherwise be 
+little more than strangers. Because of this, there is a sense of 
+fellowship between Hobbits not found in Men, Dwarves, or 
+any of the other Free People of Middle-­earth.
+Perhaps this is the root of the Hobbits’ love of food, 
+drink, and leisure. All these things are brought to their full-
+est joy when shared with loved ones, and the more with 
+whom to share, the greater the joy. Parties celebrating even 
+the slightest occasion are common in the Shire, as they are 
+excellent excuses to gather in good company, and six meals 
+a day seems perfectly appropriate when one endeavours 
+not to dine alone.
+The most common of these celebrations is, of course, the 
+Birthday Party. In a custom that would only seem strange to 
+one from outside the Shire, Hobbits accompany the tradition 
+of feasting, drinking, and dancing with the giving of gifts, 
+not to the Hobbit celebrating their birth, but rather to their 
+guests. Mathoms, serving as tokens of esteem and affection, 
+are given to those near and dear to a Hobbit’s heart on their 
+birthday. Outside the Shire, in the world of Men, the opposite 
+is done — as if a reward is deserved simply for being born. 
+A strange notion indeed.
+ALL IN A HARD DAY’S WORK
+This brings us to the next misconception regarding Hobbits. 
+That they are lazy and overly concerned with leisure. Hobbits 
+enjoy a fine afternoon fishing, or a good game of golf, to be 
+sure, and tweens (like any young rascals) will often avoid their 
+chores in favour of lighter pursuits. But one does not master 
+the fine art of baking, cooking, preserving, cultivating food, 
+raising livestock, and tending the garden without wiping a 
+bit of sweat from the brow now and again. In fact, no other 
+people of Middle-­earth were so industrious as to discover 
+the secrets of herb-­lore necessary to grow and prepare pipe-­
+weed. The art of pipe-­smoking is truly the art of the Hobbit, 
+although it has since been adopted by Men, Dwarves, and 
+even a Wizard. Instead, many Hobbits view this work as not 
+a source of toil or drudgery, but simple activities necessary to 
+live a good life among their people. As such, misery is rarely 
+found in these tasks.
+Instead, sorrow finds the heart of even the merriest of 
+Hobbits when tragedy strikes. To be sure, a burnt pie or 
+trout that slipped the hook is a source of consternation, 
+but the losses that cut to the root are those things that were 
+toiled for over generations or cannot be recovered. To see 
+a great tree felled foolishly, or lose a loved one before they 
+have had a long and joyful life, are among the greatest of 
+tragedies to a Hobbit. These are the things that cannot be 
+replaced.
+NO BUSINESS OF OURS
+As we have seen already, Hobbits have little concern for the 
+affairs and doings of those beyond their borders. Dwarves, 
+in their constant search for riches above all else, are often 
+James Smith (Order #47812382)
+
+A brief history of the Shire
+7
+seen as dangerous or too greedy, and the world of Men is 
+large, loud, and uncouth. Indeed, the last time Hobbits 
+got involved in the affairs of Men many lives were lost to 
+no avail. As for Elves, they are so far beyond a Hobbit’s 
+understanding as to be nigh indecipherable — no matter 
+how wonderful the stories make them out to be. So, for 
+most Hobbits, it is best to keep to one’s own affairs, so as 
+to keep a level head upon your shoulders, unclouded by 
+the fancies of outsiders.
+That is not to say that all Hobbits shun what lays beyond 
+the Brandy­wine. Nor that visitors never come into their lands. 
+Since the Fell Winter of 1311 and 1312, a regular interloper 
+has made his presence known to Shire-­folk. Gandalf the Grey, 
+who is by all accounts, a Wizard, seems to hold Hobbits as 
+a merry curiosity. In spite of his glorious fireworks and fan-
+ciful tales, he has a reputation as a troublemaker and his 
+encouragement has led more than one foolish young Hobbit 
+to disappear, never to return. He seems to have a particular 
+fondness for the Took clan and its cousins. In recent years, 
+he has even been held responsible for driving the previously 
+predictable and respectable Bilbo Baggins quite mad, only to 
+return him to the Shire with unlikely stories and foreign gold. 
+It is even feared that his appearance during the Fell Winter 
+may have drawn the attention of Men, as rumours have per-
+sisted since that time of Big Folk, hooded and cloaked, being 
+seen near Sarn Ford and the North Moors.
+AS FIERCE AS A DRAGON IN A PINCH
+If nothing else, Hobbits continue to be underestimated by the 
+other Free Folk, a fact that would be of great comfort to most 
+inhabitants of the Shire. Call them fat and simple, but we know 
+that history marks a fair few to be fierce and doughty. Like a 
+good meal, they must be long stirred (often over fierce heat), 
+before the truth of who they genuinely are is revealed and set 
+to table. Marcho and Blanco had the courage to travel west and 
+found the Shire. The nameless Hobbit-­archers travelled to for-
+eign parts to fight in a foreign war. Gorhendad Oldbuck dared 
+to live in the shadow of the Old Forest, as do his descendants 
+today. Bullroarer Took led his brave fellows in battle when fell 
+Goblins dared to invade his beloved Shire. Even in this current 
+generation, that tenacity remains. The Horn-­call of Buckland 
+brought Hobbits to arms against the White Wolves. And Bilbo 
+Baggins, for all his strangeness, ventured beyond the horizon 
+and over the edge of the wild only to return, and by some 
+accounts he was made richer for it in more than gold and silver.
+As to what the coming days will bring for the people of 
+the Shire, none can say. What is known is that, as before, so 
+shall it ever be in the land between the Far Downs and the 
+Brandy­wine. A fierce love of all that is simple and good will 
+remain strong and steadfast as the Hobbits of the Shire stand 
+together with kin and countrymen against whatever threat-
+ens their traditions. But until called to such duty, they shall 
+celebrate this simple life they have made for one another.
+GANDALF THE GREY
+To the great discomfort of many of the more traditional 
+Hobbits, and to the great joy of Tooks, tweens, and 
+young children, the Wizard Gandalf the Grey is known 
+to arrive in the Shire on seemingly random occasions. 
+Whether this is a quiet and secret trip to see Bilbo Bag-
+gins, or a visit heralded by Hobbit children crying for 
+fireworks at the sight of his cart and pony, the strange 
+figure has become a signal of mischief to come within 
+the confines of the Four Farthings.
+What his errands are, and when he will arrive remains 
+his own business, though certainly he only comes to the 
+Shire to stir up trouble and disturb the peace. Most often, 
+his visits take him to Bag End or into Tookland, but his 
+reasons for visiting remain a mystery. As often as not, 
+some young Hobbit disappears for a week or two after 
+Gandalf has gone on to other business — or at least that’s 
+the claim of local gossips and busybodies.
+But Gandalf is not without his admirers, particularly 
+when it comes to the matter of his fireworks. These most 
+excellent creations have become the talk of the Shire 
+since when the Old Took started to have them at his 
+Midsummer-­eve Parties, and every Hobbit, whether 
+they will admit it or not, secretly hopes the wandering 
+Wizard will grace their celebrations with his fantastic 
+displays.
+James Smith (Order #47812382)
+
+THE SHIRE
+8
+the geography of the shire
+Forty leagues it stretched from the Far Downs to the Brandy­wine Bridge, 
+and fifty from the northern moors to the marshes in the south.
+As is known to any Hobbit of good sense, the Shire comprises 
+the territories known as the Four Farthings, which are named 
+the North­farthing, the East­farthing, the South­farthing, and 
+the West­farthing. This covers the whole of the land originally 
+granted to its residents by the King, and it was only after 
+old Gorhendad Oldbuck grew too cross and his family to be 
+confined that Hobbits moved beyond these traditional bor-
+ders. Pushing beyond the Marish and over the Brandywine, 
+he founded Buckland between the river’s eastern shore and 
+the edges of the Old Forest. It has, since its founding in S.R. 
+740, been the primary domain of his people and their innu-
+merable relations: the Brandybucks.
+Even with the establishment of Buckland, the Shire has 
+grown but little over the centuries, and still holds for the most 
+part to its original bounds between the Far Downs in the west 
+and the Brandy­wine River in the east. In fact, more than a 
+few folk on the west side of the river regard Bucklanders as 
+little better than the far-­off Bree-­Hobbits, with their fancy for 
+boats. But we shall come to that in time.
+Meanwhile, far beyond Overhill, on the edges of Oatba-
+rton, the North Moors see the first and heaviest snows of the 
+winter each year, and the warm summer sun allows the land 
+to flourish all the way down to Longbottom. Though Buck-
+land is the only outlier beyond these formal borders, many 
+Hobbits that dwell in the smaller communities along them, 
+such as the miners of Scary and the fishermen of Deephallow, 
+have a reputation for being out of sorts, even if their status 
+as true Hobbits of the Shire is beyond question.
+the three-­farthing stone
+To properly relate a list of the places of importance within 
+the Shire, it is only appropriate to begin at its very heart, and 
+then explore each of these domains in turn. Whether it was 
+erected by the high king at Norbury, by the brothers Marcho 
+and Blanco, or some other thoughtful Hobbit of surpassing 
+good sense, the Three-­Farthing Stone stands in the middle 
+of the Shire.
+Tall as two Hobbits, and worn little by age or time, this 
+column serves to mark where the borders of the West­farthing, 
+East­farthing, and South­farthing meet. Indeed, it is easily visi-
+ble to any Hobbit or the rare outsider travelling on the East-­
+West Road. Though it serves no formal purpose beyond indi-
+cating the true and proper centre of the Shire for all to see, 
+the Stone is held in great esteem by all residents of the Shire 
+— save for naughty Hobbit-­children roughly playing “King 
+of the Stone” as they attempt to best one another by seeing 
+who can scramble up its slick, rocky sides the fastest (before 
+inevitably tumbling down or being knocked about by their 
+playmates).
+More than one such rascal’s name has been heard all 
+the way in Bywater, carried nearly five miles on a northwest-
+erly wind, as an angry gaffer or gammer bids them stop such 
+foolishness before they rightly hurt themselves — or worse, 
+knock down the stone. But through all the generations of the 
+Shire-­folk, the Three-­Farthing Stone has endured.
+James Smith (Order #47812382)
+
+The Geography of the Shire
+9
+A NIGHT AT THE STONE
+Recently, strange white shadows have been drifting around 
+the ancient Three-­Farthing Stone at night. Stories of ghosts, 
+mournful spirits, or even a magical curse have begun to be 
+whispered at the tables of the Stone’s Throw, the inn closest 
+to the ancient landmark, and now many are afraid to pass near 
+it after sundown. It would be a kindness, some locals say, if a 
+few brave Hobbits spent the whole night near the stone, to 
+dispel the probably baseless rumours.
+The small inn stands just a few miles east of the Three Far-
+thing Stone, and is owned by Thomas and Gilda Bunce. They 
+do a brisk business thanks to this mysterious tale. In fact, many 
+west-­bound travellers prefer to stop and sleep here when the 
+stars begin to appear. This is no accident… Thomas and Gilda 
+are responsible for spreading the rumours themselves, and 
+from time to time, they deck themselves in white sheets, and 
+wander for hours at night, or bid their mischievous children 
+do it in their stead.
+the water
+The river running across the Shire from its source in the Hills 
+of Evendim to where it flows into the Brandy­wine is simply 
+called “the Water” by the Hobbits of the Four Farthings. Lit-
+tle more than a slow-­rushing stream where it spreads into the 
+Rushock bog, it eventually resumes its eastward course and 
+runs parallel to the road connecting Little Delving and Nobot-
+tle to Hobbiton. From there, it joins with another watercourse 
+from the north to create the Bywater Pool before continuing 
+on, along the East Road all the way to the Brandy­wine. Passing 
+beyond the borders of the West­farthing, the Water continues 
+to flow east, its meandering curves dampening the soil near 
+Frogmorton and serving as the heart of Budgeford with its 
+ruling Bolger family.
+Good fishing can be found along its banks at very nearly 
+every point, save where it narrows in the Rushock, and it's 
+not uncommon to find a Hobbit angling for a fresh catch 
+or napping on the bank while they hope for a good supper.
+the east road
+If the Three-­Farthing Stone is the heart of the Shire, then 
+the East Road acts as its feet. Very nearly every Hobbit of the 
+Shire has walked this pathway at some point in their lives, and 
+legends say that it runs as far west as the Dwarven realm of 
+the Blue Mountains and all the way east to Bree and beyond 
+that to the very edge of the Wild (few, if any, Hobbits have 
+ever tested this theory…). To most it is simply a wide, well-­
+kept thoroughfare that leads travellers to tea times in Budg-
+eford or to a party in Michel Delving. As far as the Shire-­folk 
+are concerned, the East Road might as well begin at the door 
+of the Town Hole in Michel Delving and end at the Brandy­
+wine Bridge.
+On rare occasions, some foolish young Hobbit will get it 
+into their head to walk its entire length. These boasts rarely 
+amount to more than that, for such an endeavour would 
+encompass walking for about forty leagues. Still, it is not an 
+insurmountable task, and the East Road itself brings such a 
+journey within the realm of possibility for enterprising tweens 
+and adventurous Bucklanders.
+Given that most Hobbits like to maintain a leisurely stroll, 
+and regularly enjoy a walking party now and again, they’re not 
+likely to achieve more than a dozen miles or so in a day, unless 
+they set a brisk pace. Even without taking regular breaks for 
+tea or a nap, a trek from one end of the Shire to the other 
+on foot is likely to take close to a week, though given the ease 
+with which a Hobbit can be distracted by a fine meal, after-
+noon rest, or a stop off at the local inn, such a trip is likely 
+to take closer to ten days or more.
+Though the land does indeed consist of mainly green 
+rolling hills, as one draws closer to the Brandy­wine, it flat-
+tens considerably, and an already easy walk becomes all the 
+more so due to the well-­maintained road. Fortunately, there 
+are few dangers in the Shire for even the most adventurous 
+Hobbit, but those who are foolish enough to camp near the 
+Bindbole Wood or other untamed region may draw the atten-
+tion of nosy wildlife intent on sniffing out the delicacies from 
+their travel packs.
+No sight-­seeing expedition from one end of the East Road 
+to the other would be complete without several stops at the 
+many fine inns across the Shire. Many travellers make it into 
+a sort of game to stop at every tavern along the way as they 
+cross the Four Farthings, which can delay even the fastest 
+rover. The further east one is, the more such local watering 
+holes one will find: The Golden Perch in Stock, the Floating 
+Log in Frogmorton, the Stone’s Throw near the Three Far-
+thing Stone, and of course, the Green Dragon in Bywater. 
+But beyond Waymeet and its Walking Party Inn, there are 
+only a few noteworthy taverns. Michel Delving hosts no less 
+than three fine establishments of its own, though the long 
+trek across the Far Downs will leave most travellers with a 
+powerful thirst before they reach Greenholm and its unusual 
+inn, the West End.
+James Smith (Order #47812382)
+
+THE SHIRE
+10
+HOBBIT WALKS
+No road-­weary Man, doughty Dwarf, or wandering Elf 
+would consider travelling through the Shire as anything 
+more than a pleasant country stroll. It has no real natural 
+dangers and its people are, for the most part, courteous. 
+The greatest trouble a foreigner may face while visiting 
+the Shire, beyond a strange look and a few pointed ques-
+tions, is found at the bottom of a tankard or on a dinner 
+plate, given the abundance of inns that fill the little land.
+While not ones to push themselves or maintain a 
+steady pace at the cost of pausing for a meal, Hobbits 
+crossing the Shire mostly stick to familiar roads and famil-
+iar lands, but there are some dangers if a curious tween 
+or errant walking party strays into more untamed lands, 
+even within its borders.
+When a Company of Hobbits is travelling across 
+the Shire, the Lore­master must roll on the table below 
+once, using a Feat die (twice if the journey is particu-
+larly long — 50 miles or more). Each entry provokes a 
+gain of Fatigue points, that each traveller can reduce 
+with a roll of TRAVEL.
+A success reduces the total Fatigue of a Player-­
+hero by 1, plus 1 point for each Success icon (
+).
+Any remaining Fatigue is recorded on the character 
+sheets of the affected Hobbit, and counts as addi-
+tional points of Load. They will get rid of it at the rate 
+of 1 point of Fatigue for each following Prolonged Rest 
+they take.
+SHIRE JOURNEY EVENTS TABLE
+FATIGUE POINTS GAINED
+SUMMER 
+AND SPRING
+WINTER 
+AND AUTUMN
+FEAT DIE
+EVENT
+DESCRIPTION
+Trouble!
+Chased by dogs, wading through stick 
+bushes and hedgerows, etc.
+4
+5
+1–4
+Delay
+Spent too much time at the inn, took a 
+wrong turn, bad weather, etc.
+3
+4
+5–8
+A Quiet Walk
+A pleasant stroll with nothing adventurous
+2
+3
+  9–10
+Short Cut
+The journey took less time than expected
+1
+2
+Chance-­meeting
+Wandering Elves sighted, guests of travel-
+ling Dwarves, wandering Wizard, etc.
+—
+1
+These are a few examples of the type of trouble that 
+might be encountered on the road. The Lore­master is 
+encouraged to develop and expand the list of things 
+that may go wrong.
+	
+♦
+FOG ON THE EAST ROAD: One night, a heavy fog 
+rolls down from the North Moors and blankets the 
+land, and growling noises and hoots can be heard 
+from beyond the edge of sight. The Hobbits must 
+pluck up their courage and make a VALOUR roll, or 
+be unable to benefit from a Prolonged Rest that 
+night, as those ill-­sounding creatures and glowing 
+eyes in the fog linger in their minds for hours to 
+come. 
+	
+♦CHASED UP A TREE: A local farmer’s guard dog runs 
+off the property, and sets out to chase the Hobbit 
+travellers, believing them to be interlopers. If a HUNT-
+ING roll is failed, then they are unable to calm the 
+dog, and must spend the rest of the afternoon stuck 
+uncomfortably up a tree to avoid his bites. They gain 
+2 additional points of Fatigue each from hours of 
+being crammed awkwardly in the boughs of a pine.
+	
+♦
+UNEXPECTED DRINKING COMPANION: While 
+resting one night at an inn, the characters find them-
+selves drawn into a lively conversation and they 
+imbibe more than a few mugs of finely brewed bit-
+ters. If they’re not watchful of their own actions, and 
+fail a WISDOM roll, they wake up the next morning 
+feeling Weary for the following day.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+THE SHIRE
+12
+James Smith (Order #47812382)
+
+The Westfarthing
+13
+the westfarthing
+… in the Westfarthing, especially in the country round Hobbiton Hill, there grew up 
+a custom of making holiday and dancing in the Party Field, when weather permitted …
+Considered by many, especially its own residents, the most 
+important of the Four Farthings of the Shire — Buckland 
+being not counted at all, the West­farthing runs west to east 
+from the Far Downs to the Three-­Farthing Stone, and north 
+to south from beyond Little Delving to deep into the heart 
+of Tookland. A land dominated by soft, rolling countryside, 
+it is home to many of the more well-­known families of the 
+Shire, including the Tooks of Tookland, where the Thain 
+resides, and the Whitfoots of Michel Delving, where mayor 
+Pott Whitfoot lives.
+BYWATER
+If you take the road from Hobbiton going south along the 
+Water, you’ll soon come to the village of Bywater and its wide, 
+grey pool. The first building you encounter is The Green 
+Dragon Inn. A popular meeting-­place for the inhabitants of 
+both Hobbiton and Bywater, the Green Dragon saw its rep-
+utation besmirched when it was invaded by Gandalf and a 
+company of Dwarves on a spring morning some twenty years 
+ago. Indeed, the inn was the last place where Bilbo Baggins 
+was seen before he disappeared. Ruthie Overwater, a local 
+gossip, claims to have witnessed the whole affair when she 
+was barely out of her tweens — her tale tells how young Bilbo 
+was hauled away in a sack down the East Road by the Wizard 
+himself! But the inn’s excellent ale and sweet mead (not to 
+mention the fine fried fish and potatoes served up right) 
+have done quite a bit to restore the Green Dragon to proper 
+status in the eyes of the local community.
+In Bywater itself, many houses gather around the Pool. 
+A long line of proper Hobbit-­holes dots its northern bank, all 
+fronted by small gardens running down to the water’s edge. 
+A pleasant tree-lined avenue forms the section of the road 
+where it borders the water, giving it the name of Pool Side. 
+From Bywater, one can take the South Lane, leading to 
+land held by respectable farmers like Holman Cotton, who 
+moved to these parts with his two sons, soon after his wife 
+passed, and has set up a right respectable plot of land, or Old 
+Noakes, who keeps a regular table at the Ivy Bush — when he’s 
+not found at the Green Dragon Inn. Old Noakes and family 
+keep orderly hives of honey bees, allowing them to provide 
+the Green Dragon with the stock of honey they require to 
+craft mead, to trade with the locals, or to give away as birth-
+day presents to deserving friends and relatives.
+gamwich and tighfield
+Though little used, the cart-road that runs out of Little Delv-
+ing heading into the northern corner of the Shire leads to 
+the oft forgotten villages of Gamwich and Tighfield. There 
+are no Hobbit-holes here, instead, small wooden houses serve 
+as farms where locals tend to fields of swaying flax that dance 
+in the summer breeze. 
+Set between the two communities is the great rope-­walk, a 
+long and narrow stone building, likely the only one of its size 
+and type in the Shire — where strands of fiber are spun and 
+woven together to make the finest rope in the region. Here 
+works Andwise ‘Andy’ Roper, the most skilful rope-­maker in 
+the Shire, the heir of a long tradition going back at least three 
+generations. While Hobbits are certainly willing to labour at 
+many tasks, some find rope-­making to be akin to Dwarf-­work, 
+and in recent years, many families from both villages have 
+considered migrating to less remote spots in the West­farthing 
+(among them, Andy’s brother Hamfast, who has taken on gar-
+dening as his trade and has moved to Hobbiton).
+THEFT AT THE ROPE FACTORY
+A bit of chaos has come to Tighfield. A mob of angry Hobbits led 
+by Andy Roper surrounds a small, isolated farm not far from the 
+rope-­walk, waving clubs, pitchforks, and torches, and it looks 
+as though they could set the farmhouse ablaze at any moment. 
+But their consternation is easily understood: three Dwarves have 
+barricaded themselves inside the besieged farmhouse after 
+becoming the prime suspects in a brazen rope theft from the 
+factory! The Tighfield locals are angry after their polite offer of a 
+tour (which they were only offering as a matter of courtesy and 
+never expected to be accepted) has been repaid with larceny!
+The Dwarves, led by Ergi Broadbeam, have denied all 
+charges, and replied to insults with stones thrown from win-
+dows and arrows shot through half-­open doors. Poor Bess, 
+Andy’s mule, was even wounded in the crossfire! Birba Mug-
+gins, the owner of the farm that housed them, and her son 
+Bobbin, escaped just before the violence began. They heart-
+ily support forcing out the Dwarvish scoundrels at any cost — 
+even if it means seeing their own home burnt to the ground. 
+Dwarves are horrid people, Birba claims, and deserve what’s 
+coming to them.
+James Smith (Order #47812382)
+
+THE SHIRE
+14
+PROVENDER AND PALAVER AT THE INN
+Both the Green Dragon and the Ivy Bush are known for 
+their beer and their fine meals, but equally appealing is 
+the endless amount of gossip that flows from the loose 
+lips of curious Hobbits that drift in and out of these fine 
+establishments on a daily basis.
+ 
+The Lore­master can roll a Feat Die on the table 
+below to determine a random rumour or event 
+that the Player-­heroes overhear the next time 
+they drop by.
+INN GOSSIP TABLE
+FEAT DIE 
+ROLL
+RESULT
+­DESCRIPTION
+‘Mad Baggins’
+Bilbo Baggins himself stops by the inn for a rare visit while on one of his solitary 
+walks. He’s as clever as ever, talking circles around patrons with fanciful stories and 
+double-­speak. Anyone who is able to keep up with Bilbo with a successful RIDDLE roll 
+will earn themselves an invite to Bag End for tea next Wednesday!
+1
+Spell-­bound 
+Seedsman
+Rumour has it that old Holman Greenhand is about to retire from tending the gardens 
+at Bag End. It’s said that he’s been bewitched by Gandalf the Wizard, and that his 
+gifts at tending the earth have been passed on to Master Hamfast Gamgee.
+2
+Mismanaged 
+Mushrooms
+Gerda Boffin’s secret crop of mushrooms has run dry, and quite a few visitors are 
+panicked that Boffin’s Crock may become a thing of the past!
+3
+Trouble North 
+and South
+Strange men shrouded in brown cloaks have been seen south of Longbottom, linger-
+ing and spying Hobbit farmers from a distance before vanishing. What’s worse, the 
+same kind of folk have been seen nosing about the North Moors too!
+4
+Ruthie’s 
+Ramblings
+Ruthie Overwater is sitting in her rocking chair in a corner, stroking the cat in her lap. 
+She’s got a crowd of Hobbit children at her feet, repeating the tale of how Bilbo Bag-
+gins was stolen away and returned some twenty years ago. The tale gets stranger and 
+more embellished every time she tells it.
+5
+Hamfast’s 
+Harvest
+The inn is serving up potato and bacon stew tonight, the finest in the Shire, on account 
+of Hamfast Gamgee’s recent bumper crop of potatoes. He’s in attendance and awk-
+wardly accepting praise from all the locals feasting on the fruits of his labours.
+6
+Beleaguered 
+Bounder
+A local bounder, quite deep into his cups, is drunkenly rambling to anyone who will 
+listen about all manner of impossible things he’s seen in his recent beating of the 
+bounds. He demands to be taken seriously.
+7
+Took Tales
+Everyone seems to be swapping stories tonight about the unlikely deeds of the Old 
+Took, his midsummer-­eve parties not the least of these!
+8
+Celebrating 
+Childhood
+One of the local Hobbits is being toasted for the announcement that he is going to be a 
+father! The drinks are flowing freely, and telling childhood tales is mandatory tonight.
+9
+Fairy 
+Phantasms
+Rumours of Elves crossing the Shire and even being seen passing by the south banks 
+of the Bywater Pool are the topic of conversation tonight!
+10
+Unexpected 
+Party
+The Player-­heroes have arrived amidst the birthday celebration of a local Hobbit. 
+Dancing, feasting, and even the gift of a mathom are in order!
+Bree Bullies
+A pair of Bree-­Hobbit merchants have stopped for a pint while passing through the 
+Shire, and have had a bit too much. Irritated by a poor sale recently, they’ve decided 
+to try to pick a fight! Unless they can be calmed down with a PERSUADE or COURTESY 
+roll, a brawl may be imminent.
+James Smith (Order #47812382)
+
+The Westfarthing
+15
+If the Player-­heroes get involved in this mess, they must 
+decide whether they want to help the Hobbits, the Dwarves, 
+or if they want to broker a truce between the two parties. Res-
+olutions aimed at harming the Dwarves see the full and enthu-
+siastic support of Bobbin and his mother. Conversely, any offer 
+of attempting to negotiate with Ergi and the Dwarves is met 
+with strong resistance from them.
+Level heads can prevail with a few pointed questions and 
+a short investigation. Should the Player-­heroes attempt such a 
+thing, they may learn several details that offer insight into the 
+current troubles:
+	
+♦The Dwarves are angry, very offended, and ready to fight. 
+They are also completely innocent. The theft was in fact 
+committed by Bobbin, as directed by his mother, with the 
+Dwarves serving as scapegoats for the crime. (The ropes 
+are hidden in a cellar under the Muggins farmhouse).
+	
+♦
+If the Player-­heroes question locals not participating in the 
+chaos, they learn that, eight years ago, Birba’s husband 
+Golfo kindly offered to accompany some Dwarves on a 
+journey to Greenholm, near the Shire’s western border. 
+Sadly, he never returned from that journey: he got lost on 
+the way back somewhere in the Far Downs, and disap-
+peared in the wild. His body was never found, but Birba is 
+convinced that the Dwarves murdered him in his sleep and 
+stole his few possessions. Years have passed, and an over-
+whelming grief has turned to hatred towards all Dwarves 
+in the hearts of Birba and Bobbin. This hatred spurred 
+them to action when Ergi came into town, leading them to 
+believe he was the murderer of their beloved father and 
+husband.
+DWARVEN ‘SCOUNDRELS’
+Secretive, Wilful
+ATTRIBUTE LEVEL
+5
+ENDURANCE
+28
+MIGHT
+1
+RESOLVE
+5
+PARRY
++2
+ARMOUR
+2
+COMBAT PROFICIENCIES: Cudgel 2 (3/12),  
+Bow 2 (3/14, Pierce)
+FELL ABILITIES: Fierce Folk. Spend 1 Resolve point to make 
+an attack roll Favoured.
+greenholm
+More than a true village, Greenholm is a collection of modest 
+houses and a few humble Hobbit-­holes dug in the last hills 
+upon the western border of the Shire, where the East Road 
+becomes just a trail and then disappears. Few bounders go all 
+the way to Greenholm, out of Michel Delving, and they don’t 
+have much to say about the place, when they say anything at 
+all. By those rare accounts, the folk in Greenholm are strange, 
+but kind and determined, and don’t seem to need much assis-
+tance from the Watch to look after themselves and the borders.
+The most prominent family in Greenholm, and the source 
+of the locals’ unusual resolve, is that of Folcred and his broth-
+ers, a small clan of hunters who are said to have regular con-
+tact with Dwarves out of the Blue Mountains, and to be more 
+familiar with Elves than is considered proper. More than one 
+witness is said to have seen them hunting in the hills along 
+with strange, hooded individuals with an ‘elvish’ look.
+THE FAIRIES OF THE FAR DOWNS
+The Far Downs beyond Greenholm are travelled 
+by few Hobbits. There, a heavy fog clinging to the 
+green grasses often rises with the moon and burns 
+away with the new sun. The Hobbits of Green-
+holm speak of strange little creatures that conceal 
+themselves in this mist, enchanting travellers that 
+dare step off the East Road and into the gloom. 
+These fairies, as they call them, hope to snatch 
+wayward Hobbits to take as their spouses. Those 
+so enchanted are returned to the edges of the 
+Shire after the mist burns away, with dreamlike, 
+fragmented memories of a grand wedding and 
+great revelry. Marked by the people of Greenholm 
+and the rest of the Shire as having “taken a fairy 
+wife,” the common belief is that encounters with 
+these curious creatures leaves a strain of madness 
+in the blood that lasts for generations.
+NEW HOBBIT DISTINCTIVE FEATURE:  
+FAIRY-­BLOOD
+One of your ancestors is said to have “taken a fairy 
+wife”. Whether this is true or not, a vein of rebel-
+lious foolishness runs in your family and manifests 
+in you as a deep streak of mischievousness, often 
+leading you to cause trouble for its own sake.
+James Smith (Order #47812382)
+
+THE SHIRE
+16
+hobbiton
+Before the Master of Bag End went running off into the blue 
+and turned back up again about twenty years ago, earning his 
+reputation as an ‘adventurer’, the village of Hobbiton was a 
+quiet, untroubled place. Possibly the oldest of all settlements 
+of the Shire, it lies placidly against the southern side of the 
+Hill, and the currents of the Water run straight through its 
+middle. Where the road crosses the Water over a stone bridge 
+is the most prominent building of the area, the old water-­mill, 
+property of Mr. Sandyman, rising next to the Old Grange. 
+Together, those two establishments have brought respectabil-
+ity (along with bread and beer) to Hobbiton for generations.
+Most of the residents of Hobbiton make their homes in 
+traditional smials, or Hobbit-­holes, within sight of the Old 
+Grange and Sandyman’s mill, with more than a few taking up 
+residence in the neighbourhood of Underhill. Still, some of 
+the notable families still have homes of wood or stone near 
+the banks of the Water where they fish or keep small farms.
+Families from both Hobbiton and nearby Bywater often 
+travel along the road connecting the two villages, to meet their 
+neighbours and keep up with the latest news — locals have 
+yet to agree upon where the road stops being the ‘Hobbiton 
+road’ and where it becomes the ‘Bywater road’ instead. It's 
+quite common for folk from both communities to sit down 
+for a pint over dinner or supper at the Ivy Bush. More than 
+one Hobbit has been drawn by the prospect of a fresh serving 
+of Boffin’s Crock and a mug of ale, but as often as not they 
+find themselves staying for the local gossip and tale-­telling 
+that inevitably comes when one of the foolish young Hobbits 
+(or cantankerous gaffers) starts to spin a yarn. Often these 
+exchanges grow into competitions of balderdash, where the 
+rules are known to all, but spoken by none.
+THE HILL
+While formally recorded on the maps of the Mathom-­House 
+as Hobbiton Hill, it is rightfully called simply The Hill by 
+everyone in the Shire. Rising north of the Water where it 
+crosses the town, its top can be seen for miles around in all 
+directions. Halfway up its slope, the long lane of Bagshot Row 
+runs, serving as home to such prominent families of the Shire 
+as the Twofoots and Greenhands — all of whom maintain root 
+gardens and flower boxes to brighten the lane from the first 
+thaw of spring to the inevitable frosts of winter. The laughter 
+of Hobbit children at play can be heard echoing down the 
+Hill all the way into Hobbiton.
+BAG END
+Nearly one hundred years ago, when Bungo Baggins brought 
+his new Took wife out of Tookland to live among sensible 
+folk, he built for her a home of the type to which she was 
+accustomed. With a few silver pennies of his own, and more 
+than a few that Belladonna contributed to the marriage, he 
+bought up a good portion of the land in Underhill, the part 
+of Hobbiton near the top of the Hill, and built for her the 
+most lavish Hobbit-­hole outside of the Great Smials of Tuck-
+borough and Brandy Hall in Buckland. Set at the end of Bag-
+shot Row, it was appropriately and simply named Bag End.
+Belladonna must have been well-­pleased, for she set aside 
+her Tookish ways and remained by his side until her passing 
+in 1334. Since that time, Bag End has been the sole estate of 
+local oddity and Wizard-­friend Bilbo Baggins. The respect-
+ability brought to Bag End by Master Baggins’ father has been 
+worn away by the antics of Bungo’s son, who once disappeared 
+from the family estate under rumour of being kidnapped by 
+Dwarves, only to pop up just as the place was about to be sold 
+out from under him.
+With the passing of the years, Bilbo Baggins has gone from 
+being considered a respectable Hobbit, to becoming the topic 
+of all manner of strange gossip in Hobbiton and beyond. In 
+fact, some would go so far as to call him a trouble maker. To 
+HAMFAST GAMGEE
+Known to every Hobbit around the Hill, Ham-
+fast Gamgee is a simple, proper Hobbit that has 
+tended the gardens at Bag End as an apprentice to 
+Holman Greenhand for nigh on twenty years now. 
+It was Hamfast and Holman that kept Bilbo’s gar-
+den in order for over a year in spite of his absence. 
+Originally from Tighfield, and a younger brother 
+to Andwise Roper, Hamfast moved to Hobbiton 
+on invitation from Holman, a distant relative, who 
+knew that the young Hamfast didn’t intend to con-
+tinue the family tradition of rope-­making.
+With the master gardener slowly surrendering 
+to old age, Hamfast will soon be taking on the role 
+of head gardener at Bag End sooner rather than 
+later. He has developed a fierce loyalty to Master 
+Baggins, and will have more than a cross word with 
+any who speak ill of him. He isn’t afraid to swat 
+those who go prying into Bag End’s business when 
+they’re not invited — as Mr. Bilbo likes his privacy. 
+Hamfast uses this as an excuse to keep up on all 
+the gossip around Hobbiton and Bywater, which 
+he secretly enjoys almost as much as gardening 
+itself. Recently, he has acquired a property at 3 
+Bagshot Row, and he is building a house to move 
+into with his future wife Bell.
+James Smith (Order #47812382)
+
+The Westfarthing
+17
+all appearances, he is a well-­preserved gentle­hobbit, and by 
+all accounts he is generous with the treasures he recovered in 
+foreign parts — especially to some of the less well-­off families 
+and the young children of Hobbiton (legends insist that Bag 
+End is a veritable cache of gold and silver, jewels and trinkets, 
+but Baggins himself will say nothing on this matter, save to spin 
+nonsense tales of Trolls and Dragons to gullible children and 
+Tookish tweens). More and more though, lately he’s taken to 
+living an increasingly private life. In fact, except for the Wizard 
+Gandalf, the occasional Dwarf visitor, and a few close relations, 
+no one has been invited to tea at Bag End in nearly a decade.
+South of Bag End, just beyond Bagshot Row, opens a large 
+field. There stands an old, tall tree. For as long as any Hobbit 
+can recall, this tree has been standing there, the centrepiece 
+of many a great celebration in Hobbiton. Weddings, festivals, 
+and of course, birthday parties, have been held under its 
+boughs, gaining the tree its nickname: the Party Tree. Ban-
+ners and lanterns hang from its branches on such occasions, 
+and its trunk has served as backdrop for more than a few 
+long-­winded and best-­forgotten speeches
+OVERHILL
+Just over the northern slope of the Hill, at the end of 
+Northope Lane, is the small community of Overhill. Most 
+homes there are built above ground, to leave more soil for 
+tending and growing. Its residents are well known for their 
+habit of going north to pick mushrooms and to hunt. In fact, 
+Gerda Boffin, whose reputation is tied to her uncanny ability 
+to find a veritable wealth of mushrooms, has made quite a 
+fortune for herself by selling her finds to the Green Dragon 
+Inn (which is renowned across the Shire for its mushroom 
+and thyme soup, affectionately called “Boffin’s Crock”).
+THE SECRET OF GERDA BOFFIN
+Boffin’s Crock, and the mushrooms it uses, are the talk of the 
+West­farthing. But no one knows where exactly Gerda Boffin 
+finds them. She keeps no gardens or mushroom tents near her 
+home, and is never seen trading for mushrooms with anyone. 
+It’s a mystery to everyone from Overhill to Bywater, and she’s 
+not giving anyone any explanation. As she’s getting on in years, 
+many are afraid the secrets of her recipe and her crop may pass 
+on when she does. But a few have puzzled out that she does 
+head a few times a week north towards the Bindbole Wood at 
+the crack of dawn, and always returns a few hours later with a 
+basket full of fresh mushrooms.
+Tracking Gerda to her secret mushroom ‘spot’ requires 3 
+STEALTH rolls. A single failure means that the players lose sight 
+of the sly Hobbit and need to pass a HUNTING or SCAN roll to pick 
+up her trail again; a second failure means she notices them and 
+will shoo them away, unless they pass a PERSUADE or RIDDLE roll 
+to convince her they are just going about their business. Failing 
+a third roll means that Gerda leads them on a wild goose chase 
+to a false location, making the players lose her tracks for good.
+Player-­heroes who manage to track the wily mushroom 
+farmer to her secret spot discover that the secret ingredient for 
+Boffin’s Crock grows in but a single location: a great hollowed-­
+out tree in the Bindbole, where, away from sunlight and prying 
+eyes, great white-­capped mushrooms of amazing size grow on 
+the moist soil and on the interior of the bark. Gerda would go 
+to great lengths to keep her spot a secret, striking very nearly 
+any bargain — though she would be quite cross with the busy-
+bodies who discovered her secret.
+Those who discover Gerda’s secret will undoubtedly draw 
+her ire at first, though once she realizes her secret is safe with 
+the Player-­heroes, what began as a most awkward relationship 
+could develop into a genuine friendship. It’s quite possible the 
+characters may be invited to Gerda’s personal table to sample 
+the freshest and best mushrooms available!
+James Smith (Order #47812382)
+
+THE SHIRE
+18
+little delving
+Due south of Nobottle, with a short trail across the White Downs 
+connecting the two, is the village of Little Delving. Named as 
+if it was a younger sibling to Michel Delving, its people like to 
+think that the two settlements are very alike. In truth, the Hob-
+bits of Little Delving remain humble in comparison to their 
+counterparts in Michel Delving; small houses with neat gardens 
+are packed tightly together on rolling hillsides. Little Delving 
+is particularly well-­regarded for its livestock — flocks of sheep 
+graze freely on the untended grassland to the west of the village.
+The main building of Little Delving is an old rounded 
+tower house, once serving as a watchtower and beacon for 
+the western border of the Shire. Now it is used mainly as an 
+enclosure where the livestock is herded in times of particu-
+larly bad weather.
+michel delving
+If Hobbits followed the ways of Men and named a town as 
+their capital, that would be Michel Delving. The chief town-
+ship of the Shire is nestled in the rolling countryside that is 
+the heart of the White Downs. Many wealthy gentlehobbits 
+are proud to call this their home, and mayor Pott Whitfoot 
+keeps a fine home in the largest Hobbit-­hole in the West­
+farthing outside of Bag End: the Town Hole. From here, the 
+Mayor of the Shire ensures that the Shirriffs maintain what 
+few duties they have in these days of peace (mainly, presiding 
+at banquets), and oversees the Messenger Service and the 
+Quick Post in his position as Postmaster.
+The true jewel of Michel Delving, however, is the local 
+museum. Called the Mathom-­house, it sits upon the hill just 
+south of the Town Hole. There, cantankerous custodian Malva 
+Slowfoot and her husband Bingo tend to a veritable hoard of 
+Hobbit-­treasures, or ‘mathoms’, as Hobbits call them. These 
+range from a pair of sparkling diamond studs once owned by 
+Gerontius Took, to a coat of silver rings supposedly worn by 
+Bilbo Baggins that was gifted to him by a Dwarven king. Other 
+oddities include a collection of wheeled contraptions known 
+as ‘velocipedes’ constructed by Tom Sandyman some time ago, 
+and the first tobacco pipe used by Tobold Hornblower him-
+self (as can be readily seen by these examples, Hobbits call 
+‘mathoms’ all those objects they come to own that they have 
+no immediate use for, but are unwilling to just throw away).
+The Mathom-­House is particularly renowned for its exten-
+sive collection of cookbooks, genealogical records, compila-
+tions of Hobbit-­lore, old weaponry, and maps. Some of these 
+maps date as far back as the days of Marcho and Blanco them-
+selves, or so the legend claims. Particularly troublesome young 
+Hobbits sometimes take it upon themselves to see if they can 
+snatch some mathom of minor importance from under the 
+nose of the Slowfoots, who take pride in their meticulous 
+care of each and every item in the museum’s catalogue. In 
+recent years, the couple have even gone so far as to put locks 
+on the door of the Mathom-­House, to deter what they call 
+“the worst folk to invade the Shire since the days of Golfim­bul 
+the Goblin.” All this confustication has only driven naughty 
+Hobbit-­boys and Hobbit-­girls to find new and more devious 
+methods to drive Malva and her husband to distraction for 
+their own entertainment.
+THE FREE FAIR
+Every year, during the high summer days of Lithe (around 
+Midsummer), a Free Fair is held on the White Downs, a few 
+miles west of Michel Delving. For three days (four in a leap 
+year) Hobbits from across the Shire join in merriment to cel-
+ebrate the bounty of the land, feast among friends, and set 
+up stalls in hopes of selling their own wares. Great stores of 
+food and ale are drawn up from the storage tunnels where 
+they have been gathered in the preceding weeks, and one 
+can be assured that all corners will, in fact, be quite filled up 
+during the Free Fair.
+Once every seven years the Free Fair also hosts the elec-
+tion of a new Mayor (or the confirmation of the previous 
+one); the last election occurred in the year 1357 S.R., when 
+old Cotman Bunce resigned his office, and Pott Whitfoot was 
+elected in his place.
+James Smith (Order #47812382)
+
+The Westfarthing
+19
+CONCERNING THE GREY PILGRIM
+If the Player-­heroes ask around about the latest news or 
+rumours concerning Gandalf, the Lore­master can roll a 
+Feat die to see what is being said regarding the latest 
+disturbances brought about by the Grey Pilgrim.
+GANDALF GOSSIP TABLE
+FEAT DIE 
+ROLL
+RESULT
+Inquiring into the affairs of the Wizard has drawn his personal attention, and Gandalf himself shows up. 
+Now, what errand or adventure could he have in store for the Player-­heroes?
+1
+“Bilbo is digging new tunnels into the Hill on orders from Gandalf! If he goes any deeper, the whole of 
+the Hill and everything upon it is going to collapse in upon itself and we’ll be buried in dirt and gold!”
+2
+“Gandalf is in league with Gerda Boffin, I say! That’s how she makes her crock, I tell you. I won’t be eat-
+ing no soup with Wizard-­enchanted mushrooms. Who knows what kind of deal she’s made with that 
+conjurer!”
+3
+“I heard that Paladin Took has made some kind of deal with the Wizard, trading blessed farmlands for 
+some strange promise. It’s not right I say.”
+4
+“I don’t rightly know what he’s up to, but last I heard Gandalf was wandering the North Moors, chasing 
+giants and casting curses. I saw lightning strike the hills to the north at night!”
+5
+“Found another Dragon, I tell you! That’s what I heard! He’s looking for some new Hobbit to drag off 
+into the wilderness now that Baggins has gone all cracked!”
+6
+“It's no business of mine, but I saw Gandalf arguing with Lalia Clayhanger down in Tuckborough on 
+some matter related to the Old Took. Even if I was a Wizard, I wouldn’t tangle with that one.”
+7
+“Saw him coming up south from Sarn Ford near Longbottom and he wasn't alone. Talking to some 
+fierce-­looking and dirty traveller he was. Nothing good will come of it, mind you. Nothing good at all.”
+8
+“Trundling down the Stock Road on his cart he was, on some errand all his own. Paused and as easy as I 
+talked to my gaffer at Sunday dinner he struck up a conversation with a bird. He’s cracked, I tell you.”
+9
+“I heard from Mr. Mudwort down in Deephallow that he was knee-­deep in the mud of the Overbourn 
+Marshes, trying to conjure the dead! Keep that one and anyone who dares call him a friend away from me!”
+10
+“Stayed the night in Brandy Hall, he did. Sat at the Master of Buckland’s table like he was some long-­
+lost kin! Imagine that?! Then, pleased as you can be, he opened the Hay Gate and disappeared into the 
+Old Forest like it was just a Sunday stroll.
+A small group of Bounders or some ill-­tempered gossip accuse the Player-­heroes of being in league 
+with the Wizard in some conspiracy that will come to a bad end. The Player-­heroes will need to make a 
+PERSUADE or RIDDLE roll to convince their accusers of their innocence.
+Until a few decades ago, Gandalf the Grey himself appeared 
+regularly at the Free Fair. He used to hold a special show based 
+on his magical fireworks, during the Old Took’s Midsummer-­eve 
+parties — a display no Hobbit could ever forget. Unfortunately, 
+the Wizard hasn’t shown up for the occasion in the last forty 
+years or so, since his good friend the Old Took died.
+James Smith (Order #47812382)
+
+THE SHIRE
+20
+THE MESSENGER SERVICE 
+AND THE QUICK POST
+Hobbits like to keep in touch with their friends and more 
+likeable relatives, and those who know their letters enjoy 
+writing almost every day. This regular correspondence is 
+delivered anywhere within the boundaries of the Shire by 
+the Messenger Service and the Quick Post. The first employs 
+numerous Messengers, tasked with delivering letters and 
+small packages between the homes and businesses of the 
+Four Farthings. The Quick Post is employed only on official 
+business, to deliver messages from the Mayor, or between 
+the Shirriffs, for example, and is manned by a smaller num-
+ber of quick runners.
+Every larger township, like Hobbiton or Bywater, has 
+its own post-­office, and a number of postmen making the 
+rounds, but the main Post-­office is in Michel Delving. Post-
+men and Messengers can be seen carrying out their duty 
+from there to Greenholm, Stock and everywhere in between. 
+No postmen reach Buckland though, as most letter carri-
+ers are wary of the communities along the eastern banks of 
+the Brandy­wine.
+Existing for as long as any Hobbit can recall, serving as a 
+postman is a position of respect among the communities of 
+the Shire. Perhaps this is why a blind eye gets turned when 
+a jar of preserves arrives at its destination a little less than 
+full or no one bothers to mention that their sack of apples 
+arrived a bit light. After all, walking one’s appointed route 
+can be hungry work.
+needlehole
+A village in the northern reaches of the West­farthing, Needle-
+hole is cut in two by the Water as it comes down into the 
+Rushock Bog. A small stone bridge crosses the stream here, 
+allowing the road to continue eastwards towards the village of 
+Oatbarton. The Hobbit families of Needlehole live in sturdy 
+homes of wood and stone within sight of the Water, and have 
+something Dwarvish about them — by most accounts, they 
+wear boots when they go wood-­gathering and duck-­hunting 
+in the Rushock Bog to the south!
+If Needlehole is known for anything, it is for the pipes 
+that their inhabitants craft using bog-­wood, tree-­trunks that 
+have lain buried in the southern wetland for centuries, if not 
+millennia. Hard as stone, the trunks of bog-­wood must be 
+carved with special tools that the inhabitants of Needlehole 
+obtain by trading with Dwarves. Bog-­wood pipes are dark in 
+colour, their hues ranging from a deep brown to black, with 
+the deeper shades coming from the most ancient and most 
+prized qualities of bog-­wood.
+nobottle
+Tucked away in a remote corner of the West­farthing, where 
+the chalky heights of the White Downs become low knolls 
+covered in thick grass, is the tiny community of Nobottle, a 
+village home to no more than four or five families of Hob-
+bits. Unlike most other villages of the Shire, the residents of 
+Nobottle make their homes primarily in Hobbit-­holes, with 
+MAYOR POTT WHITFOOT
+Elected Mayor just over three years ago, Pott Whitfoot fan-
+cies himself a consummate Hobbit about town, and attri-
+butes to his role as mayor an importance that is scarcely 
+recognised by anyone else in the Shire. His obligation 
+to preside at all public events, ensure the Bounders and 
+Shirriffs are doing their due diligence, and to see that the 
+speed and quality of the Messenger Service and Quick 
+Post are beyond reproach, is of supreme importance to 
+him. After all, if he’s not doing his proper mayoral duties, 
+he won’t have a place of honour at the many tables he’s 
+invited to across Michel Delving, and he is the first to point 
+out that dinner with the Mayor is a high honour indeed.
+For all his self-­importance, Mayor Whitfoot is a sen-
+sible enough fellow and hopes to avoid any trouble or 
+gossip-­worthy activities during his tenure. He is quick to 
+pass along any requests to address strange goings-­on 
+to his Bounders, and send them after any foolish young 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+Hobbit reckless enough to traipse into the North Moors 
+or beneath the eaves of the Woody End. Best to wash 
+his hands of such concerns, and leave them to younger, 
+less dignified Hobbits.
+James Smith (Order #47812382)
+
+The Westfarthing
+21
+only one or two houses constructed along its outer edges. 
+They keep mostly to themselves, quietly tending their land 
+and growing their crops of bilberries and wheat. They will, 
+when the occasion strikes them, venture upon a day trip to 
+Little Delving or Needlehole, but will rarely go any further. 
+By all accounts they mind their own business, and expect 
+others to do the same.
+But if the inhabitants of Nobottle can be considered to 
+be somewhat unwelcoming, they are considered to be jolly 
+fellows when compared to the Banks, their neighbours, a 
+handful of closely-­related families of fishermen dwelling on 
+the shores of the Water a few miles to the northeast of the 
+village. Already regarded with suspicion for their connec-
+tion with the North-­Tooks of Long Cleeve, their reputation 
+is made even more sinister by their preference to move about 
+on boats along the Water.
+rushock bog
+As the Water rolls off the North Moors into the Shire, it slows 
+down upon reaching Needlehole, until the river vale becomes 
+almost flat, and the stream starts to meander in a hundred 
+rivulets. The surrounding landscape is that of a vast marsh-
+land stretching for several miles, and a walk across it is likely 
+to leave mud between one’s toes. No Hobbit has reason to 
+venture there for leisure though, as the area is thick with sting-­
+flies and gnats — in the warmer months of the year they can 
+be seen rising as a cloud at sunset.
+Despite these terrible threats, daring duck hunters and 
+gatherers of bog-­wood from Needlehole enter the marsh sev-
+eral times a year. They can be seen traipsing around wearing 
+boots, the duck hunters armed with bows and carrying the 
+carefully-­painted wooden ducks they use as decoys, the wood 
+gatherers leading sturdy ponies that they will use to pry their 
+prized tree-­trunks out of the bog’s cold embrace.
+Following the course of the Water through the bog is 
+a back route to reach Hobbiton, and some hunters from 
+Needlehole walk all the way there to sell their catch to the 
+local inns and families.
+CHILDREN'S STORIES
+Although it is true that adults like to spin tales and gossip about 
+it over a pint, no true strangeness or oddity has ever been 
+observed in the Rushock Bog by any grown Hobbit. In fact, 
+only the younger lads and lasses can say that they have ever 
+seen the little black creatures with large, luminous eyes that 
+crawl through the mud at night…
+Once in a while, tales told by Hobbit children about these 
+shy and disturbing entities surface  in Overhill, Hobbiton, or 
+Needlehole. Described as more unusual than threatening, they 
+have always been promptly dismissed as imaginary bugbears 
+by parents and relatives, leading the children to keep their 
+sightings largely to themselves, a secret whispered from ear 
+to ear. The most adventurous among them have developed 
+all manner of unlikely theories, and have started keeping 
+watch for long hours at the edge of the bog, setting rudi-
+mentary traps at seemingly random locations, in the hope 
+of capturing one of what they have collectively come to call 
+the “Bog Beasts.”
+To this day, in spite of many claims that some little Hobbit-­
+boy or Hobbit-­girl “very nearly got one,” a Bog Beast has never 
+been captured. Strangely, as Hobbits grow from child to tween, 
+their interest in the Bog Beasts fades, and by the time one has 
+reached the age of maturity, they seem to preserve no mem-
+ory of the creatures at all.
+the tookland
+The western range of the Green Hills rising in the West­
+farthing has always been known as the Tookland since time 
+out of mind. It is aptly named, for it is the ancestral home 
+of what is considered by many to be the chief family of the 
+Shire, the numerous and well-­respected Took clan. Here, 
+small farms dot the rolling hills where one Took cousin or 
+another grows grain and barley for bread and beer, keeps 
+hives of buzzing bees for honey and mead, or makes their 
+living hunting small game for fur and meat.
+The Tooks are renowned for being a bit too adventurous 
+for traditional Hobbit tastes, and while that may be so, there’s 
+a charming irrepressibility about the entire clan that often 
+reveals itself in the wit and wisdom that pervades the gaffers 
+and gammers of that family. This reputation for mischief is 
+of little concern to the Tooks, and in fact, is a point of pride 
+to more than a few of that line.
+Unlike in many other regions of the Shire, the Wizard 
+Gandalf always receives a warm welcome whenever he passes 
+through the Tookland, as no one among the members of the 
+clan forgets that the Grey Pilgrim was a good friend of the 
+most famous Took of them all, the Old Took himself.
+In spite of their propensity for the outlandish and the 
+friendship of Wizards, the Took Clan is greatly respected by 
+everyone in the Shire. This is likely due to the legacy they 
+carry as the holders of the Thainship since Isumbras the First 
+accepted both the title and role from Gorhendad over five 
+hundred years ago.
+James Smith (Order #47812382)
+
+THE SHIRE
+22
+tookbank
+A winding trail run-
+ning east off Whitwell 
+on the North Road reaches 
+the village of Tookbank, upon 
+the westernmost rises of the Green 
+Hills. The scent of apples ready to be 
+plucked from the appledores, the sound of 
+delighted children playing “Greenfield Gob-
+lin,” or the sight of mushroom tents are encoun-
+tered before the round doors of any Hobbit-­holes 
+become apparent.
+Tookbank is a small village, much smaller than the 
+nearby Tuckborough, to the chagrin of its inhabitants who 
+feel they are looked down on by their neighbours. A wish 
+to avoid any contact might explain why no road leads from 
+Tookbank to the nearby town, and why no one in the two 
+communities has ever demonstrated the desire to build one.
+Rumours outside the Tookland speak of an extensive 
+network of tunnels dug under the Green Hills and joining 
+Tookbank with the Great Smials, and comprising vast under-
+ground halls where the Tooks join in secret merriment sev-
+eral times a year.
+tuckborough
+Tuckborough is the largest village in the Tookland, and the 
+one counting more Hobbit-­holes than any in the entire Shire. 
+It is here that Great Smials stands, the many-­tunnelled man-
+sion of the Took clan, dug three centuries ago at the time of 
+Isengrim the Second. Known also as the ‘Great Place of the 
+Tooks’, it’s a veritable maze of bedrooms, parlours, kitchens 
+and dining halls, serving as the home of a multitude of family 
+members. Deep inside it lies a place known simply as ‘the old 
+room’, the large hall where Gerontius, the Old Took, spent 
+most of his life. It is said that the room didn’t see changes to 
+its decor and furniture for decades, for the Old Took liked 
+it exactly as it was, and that to this day no Hobbit — Took or 
+otherwise — has 
+dared to move 
+so much as a leaf of 
+parchment, let alone Old 
+Took’s rocking chair! In fact, 
+his reading glasses sit on an end 
+table by the chair next to his pipe, 
+where he sat them down on the night 
+before he passed forty years ago.
+Since the time when Gorehendad Oldbuck 
+gave up the title of Thain and moved across the 
+Brandy­wine and Isumbras the First assumed it, Great 
+Smials has also been the seat of the Thainship. Though 
+the title is little more than an honorific these days, respect 
+for the position is still maintained — especially among the 
+Hobbits of the West­farthing. Fortinbras the Second has been 
+Thain nigh on thirty years now, and by all accounts he is as 
+good and wise a gentlehobbit as any could ask for.
+waymeet
+A merry stroll east out of Michel Delving along the East Road 
+will lead a wandering Hobbit to the crossroads at Waymeet. 
+Appropriately named, it is not only a crossroads, but also 
+where Hobbits from across the West­farthing come together 
+to trade goods and gossip in equal measure. In fact, many 
+of the homes have adjacent or attached sheds to act as both 
+storage and storefront for trinkets and wares readily available 
+to any passersby travelling along the East Road.
+A collection of tables sits right along the road in the mid-
+dle of Waymeet, before the doors of the Walking Party Tavern. 
+It serves as an open-­air tap house of sorts, where visitors can 
+quench their thirst before going about their business, and 
+maybe purchase whatever mathom catches their eye in the 
+tiny shops that line the thoroughfare. More than one Dwarf 
+crossing the Shire has stopped at the tables of Waymeet for 
+a pint and a game of ninepenny marl, while being forcefully 
+brought up to date on the latest gossip offered by the idle 
+gammers and shopkeepers.
+James Smith (Order #47812382)
+
+The Westfarthing
+23
+A DAY IN WAYMEET
+A trip to Waymeet is never boring, and if the Player-­
+heroes opt to spend an afternoon, the Lore­master can 
+roll a Feat Die on the table below to determine a random 
+event or design one themselves.
+WAYMEET JOURNEY TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+Chance Encounter
+The Player-­heroes encounter a well-­known local or famous visitor as they pass 
+through Waymeet. Examples include Bilbo Baggins, Gandalf the Grey, Balin the 
+Dwarf, or even catching a glimpse of an Elf moving west just at the edge of town.
+1
+Mistaken Identity
+A local Hobbit mistakes a Player-­hero for a distant, long absent relation, and 
+insists on recalling old family stories the character has no knowledge of.
+2
+A New Friend
+The Player-­heroes strike up a pleasant conversation with a fellow visitor at Way-
+meet who invites them to tea the next time they’re about.
+3–4
+A Foolish Trade
+The character finds they’ve made a bad deal at the market and is down a few 
+coins or has swapped a valuable item for some useless junk.
+5–7
+A Peach of a Deal
+The character was able to strike a good bargain and walked away with a new tool 
+or item that may be of some use in the future, as determined by the Lore­master.
+8
+Rumours
+The Player-­heroes spend a long evening swapping news with the locals and 
+learn a piece of information or clue that offers insight into one of their upcoming 
+adventures.
+9
+Idle Words
+The Player-­heroes hear news about some other person or place in the Shire that 
+turns out to be false but seems credible at the time.
+10
+Tales from Beyond 
+the Brandy­wine
+The Player-­heroes learn some news from beyond the borders of the Shire while 
+having a drink at the Walking Party Tavern.
+Robbed!
+A Player-­hero must make an AWARENESS roll, or they realise someone has picked 
+their pocket during the hustle and bustle of the day. An item very important to 
+them has been stolen!
+whitwell
+A sure sign that one is about to enter the village of Whitwell 
+is the sound of the crowing roosters and clucking hens that 
+wander its coops and farms. This small community is known 
+for its chicken farmers, and many members of their flocks 
+find their end at tables across the Shire. In spite of its humble 
+appearance, Whitwell serves as a hub of travel in the Tookland, 
+with pipe-­weed coming up from the farms of Longbottom, 
+travellers going south from Waymeet, and Tooks arriving end-
+lessly from Tuckborough. These visitors will find the finest 
+roast chicken in the Four Farthings if they sit down at a table 
+at the Fairest Fowl Inn, which sits right upon the crossroads 
+at the heart of Whitwell.
+The latest news heard over these fine meals is that of a 
+young enterprising Hobbit by the name of Paladin Took who 
+has recently come to Whitwell from Tuckborough. A first 
+cousin once removed of Thain Fortinbras (on his father’s 
+side), Paladin stands out as an oddity among the many 
+chicken farmers, for he has begun tilling land and planting 
+seeds in hopes of turning his new farm into a grand enter-
+prise worthy of attracting a fine wife.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+THE SHIRE
+26
+the southfarthing
+How Old Toby came by the plant is not recorded, for to his dying day 
+he would not tell. He knew much about herbs, but he was no traveller.
+As the land of the Tooks rolls east and gives way to the Green 
+Hill Country, the wide fields of the South­farthing spread 
+southwards from the Three-­Farthing Stone. It is a sparsely-­
+populated land by Hobbit standards, traversed in the north 
+by the Stock Road that runs through the Yale in the East­
+farthing, and bordered by the Shirebourn river to the south-
+east. Largely made up of isolated farms and wide fields, it is 
+here that the best wine found in the Shire is produced, and 
+where the most prestigious varieties of pipe-­weed are grown.
+longbottom
+Longbottom is the pride of the South­farthing. Perhaps less a 
+town and more a collection of many farms with stout homes 
+of wood and stone, Longbottom outgrew its boundaries at the 
+time of Tobold Hornblower, the first Hobbit to grow the true 
+pipe-­weed in the Shire. Each farm is surrounded by vast, fur-
+rowed fields, from which the leaf is harvested and processed.
+It is from around here that the three most popular brands 
+of pipe-­weed come from: ‘Longbottom Leaf’, ‘Old Toby’, and 
+‘Southern Star’. Carts loaded with barrels carrying the Horn-
+blower brandmarks can be seen travelling up and down the 
+road at any hour of the day, headed to the farthest corners 
+of the Shire. There are even rumours of enterprising Hob-
+bits making the journey all the way to the Blue Mountains, 
+west beyond the Shire, or eastwards over the Brandy­wine all 
+the way to Bree — though perhaps those travelling in that 
+direction are doing so more to reinforce the superiority of 
+the Shire leaf over the Southlinch crop grown in those parts.
+Wherever their destination may be, travellers leaving 
+Longbottom and taking the road north are likely to stop at 
+the inn at Sparrow’s Rest, located about a day’s travel towards 
+James Smith (Order #47812382)
+
+The Southfarthing
+27
+THE INN AT SPARROW’S REST
+Travellers stopping by the Sparrow’s Rest for a pint and 
+dish of strawberries and cream are sure to hear a tale or 
+two. Lore­masters can choose or roll a Feat Die to deter-
+mine the nature of the most recent tidings.
+SPARROW’S REST GOSSIP TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+Elvish 
+Encounter
+A Hobbit child became lost in the Woody End recently and was feared to have per-
+ished, but two days later she was seen being led to the edge of the village by noth-
+ing less than an Elf! Onlookers claim that after the child came safely within the bounds 
+of the village, the Elf vanished right before the eyes of everyone looking.
+1
+Mole Mischief
+Moles have been digging long tunnels under the lands of farmers in the Yale and 
+leaving mounds in curious geometric patterns in the soil.
+2
+Raucous 
+Rooks
+Flocks of large black birds have flown up from the south of Dunland and begun 
+nesting in the trees around Sarn Ford. They seem to take a keen interest in travellers, 
+watching them with an uncanny level of intensity.
+3
+Pine Peaks
+Large piles of pine cones have been found along the edge of the Bindbole Wood, 
+stacked nearly as high as a Hobbit. None of the locals have claimed responsibility or 
+seen who or what is doing this, and no animal tracks or footprints have been seen 
+near the piles.
+4
+Missing 
+Merchants
+A Hobbit grocer from Willowbottom taking a shortcut through the Woody End on 
+his way to Woodhall became lost and was discovered three days later, asleep on the 
+Stock Road. He claims to have no memory of falling asleep, only that he stepped into 
+the forest and woke up on the road a moment later.
+5
+Southern 
+Strangers
+While returning from a trip to Longbottom, a solitary Hobbit claims he encountered 
+a pair of sallow-­faced big folk who had an ill-­favoured look about them. They even 
+drew knives and moved to approach him before he escaped in the tall grass.
+6
+Mysterious 
+Minstrel
+Young Gilly Brownlock is sitting in the Sparrow’s Rest, playing a melancholy song 
+on her tin whistle. If asked where she learned it, she says from fairies that live in the 
+White Downs.
+7
+Finches Flock
+Many of the folk gathering firewood from the woods near Pincup have seen a small 
+flock of finches following them, singing gentle and soothing songs.
+8
+Garden Gifts
+While picking strawberries in her garden in Willowbottom, the normally pesky squir-
+rels that plague her crop came right up to Scarlet Kettlebottom and began to pick 
+them right off the vine and set them at her feet before running off into the forest.
+9
+Murmuring 
+Melody
+For the past three nights, whenever the wind blows out of the north, everyone in 
+Deephallow can hear a gentle song upon the breeze that lingers for a few hours after 
+nightfall. No one knows the source.
+10
+Bosco’s 
+Badger
+Bosco Rumble from Longbottom claims he was cornered and very nearly attacked by 
+a badger near Sarn Ford, until one of the Big Folk seemed to step out from nowhere, 
+whispered strange words to the beast, and then motioned for it to run off. The Man 
+had fierce eyes and a beard, but pulled his hood up before Bosco could get a better 
+look.
+Bloodthirsty 
+Beast!
+Bounder Burt Underhill, from Woodhall, returned home last week, bloody and wounded! 
+In a sheer, raving panic, he claimed he was ravaged by the Black Wolf of Woody End!
+James Smith (Order #47812382)
+
+THE SHIRE
+28
+the border with the West­farthing. A welcome sight to the 
+weary eyes of every travelling pipe-­weed merchant, the inn 
+used to be a small watchtower, and takes its name from the 
+many birds nesting under its eaves. By all accounts, no inn 
+offers a better serving of strawberries and cream anywhere in 
+the Shire, and a more diversified source for gossip — pipe-
+weed merchants hail from all over the four Farthings, and 
+find the inn to be the perfect place for the exchange of news.
+pincup
+Nestled on the southern slopes of the Green Hill Country, 
+Pincup is home to a handful of Hobbit families that live quiet 
+lives in relative isolation. Most live in modest Hobbit-­holes 
+among the shaded hillsides, others keep small farms just 
+beyond the shadows of those mounds for growing autumn 
+crops like radishes, turnips, and carrots.
+But it is going west that one reaches Pincup’s true and 
+only claim to fame: its vineyards. Raised on the steep hillsides 
+facing south, it is here that the grapes used to produce the 
+best wine in the Shire are cultivated — known simply as Old 
+Winyards, it is a strong red wine that grows in value as it ages, 
+so much that older bottles are treasured. Bottles of vintages 
+from as far back as a century have been given by Tooks to their 
+relations and close friends on birthdays and special occasions 
+since time out of mind.
+sarn ford
+Far beyond what any reasonable Hobbit would call a proper 
+part of the Shire, is the stone river crossing of Sarn Ford, at 
+the southernmost border of the South­farthing. During the 
+drier seasons, the Brandy­wine becomes so shallow here that 
+it can be waded without any danger. In Spring and Autumn 
+the thaw and heavy rains make it less safe, if it wasn't for a 
+number of large, flat rocks, set across the ford in times of old, 
+allowing travellers to use them as stepping-­stones.
+Sarn Ford is a deserted place, and for some reason, no 
+Hobbit in their right mind would think of spending more 
+time there than what’s strictly necessary to cross the river — 
+more than one traveller on the South Road claims to have 
+seen strange, hooded men wandering about in its vicinity.
+THE WATCH OVER SARN FORD
+A long time ago, in an age of the world beyond the reckoning 
+of Men and Hobbits, Sarn Ford was the site of a terrible battle. 
+An invading army out of the Black Land was broken with great 
+slaughter, leaving an indelible mark across the region that can 
+still be perceived after long millennia — Hobbits rarely linger 
+here for any length of time, as the air itself seems to disagree 
+with their cheerful disposition.
+Whether they themselves know about the past history of 
+the place or not one could not say, but the Rangers of the North 
+keep a constant watch over the crossing. The ford is the first safe 
+passage over the Brandy­wine river — the next one being the 
+Bucklebury Ferry, more than fifty miles upriver to the north, and 
+travellers coming from the south along the road must use it to 
+enter the Shire. The Rangers take great care not to reveal their 
+presence, disappearing quickly into the wilderness if they are 
+in risk of being spotted. A few secret caches of supplies, such 
+as firewood and dried meat, and at least one store of weapons, 
+have been set up close to the ford, marked with runes and eas-
+ily overlooked as another minor oddity from outside the Shire 
+by all but the most educated of Hobbits.
+HALLAS AND HALBARAD
+The captain of the Rangers tasked with watching over Sarn Ford 
+and the southern borders of the Shire is a Man called Hallas. 
+Wise in old lore and a veteran fighter, Hallas has grown fond 
+of the pipe-­weed of the halflings. In the company of his son, 
+Halbarad, they sometimes enter the South­farthing disguised 
+as merchants from Tharbad, and visit the Inn at Sparrow’s Rest 
+to keep up with the latest rumours (and to fill their pipes with 
+the best Hornblower leaf).
+the shirebourn river
+A good part of the eastern border of the South­farthing is 
+marked by the Shirebourn, the watercourse flowing from the 
+Green Hill Country across many miles of lowlands. Once it 
+meets another stream, the Thistle Brook, flowing out of the 
+East­farthing at Willowbottom, the Shirebourn slowly winds its 
+way for about fifteen miles, until it reaches the Brandy­wine 
+near Deephallow. The Overbourn Marshes spread at the river 
+mouth, among reeds and willow thickets.
+Residents of the South­farthing rarely venture so far east 
+though, except for a number of angling enthusiasts who dare 
+go boating on the Shirebourn in small rowboats. Certainly no 
+one enters the marshes — not even the nearby residents of 
+Deephallow in their Dwarf-­boots would dare go about trudg-
+ing in this bog. Nothing dangerous has emerged from the 
+marshes in living memory, but mournful noises and barely 
+heard songs seem to drift above its still waters, carried by the 
+breeze from the Old Forest.
+James Smith (Order #47812382)
+
+The Northfarthing
+29
+the northfarthing
+Except on the high moors of the Northfarthing a heavy fall was rare in the Shire,  
+and was regarded as a pleasant event and a chance for fun.
+The North­farthing is the only quarter of the Shire whose bor-
+ders are not marked by the Three-­Farthing Stone. Most folk 
+come to this area by way of the Northway Road, between Bywa-
+ter and Frogmorton, heading on up over the Water and across 
+the northern half of the East­farthing. The surest sign that you 
+have crossed into the North­farthing is the fresh, fragrant air 
+that sweeps across the Greenfields and slips between the trees 
+of the Bindbole Wood. Winters in this region tend to be a bit 
+cooler and longer than in the rest of the Shire. Still, in those 
+seasons of lesser sun, a blanket of winter snow is no small 
+beauty to awaken to each morning as one sets the kettle to boil.
+the bindbole wood
+Filled mostly with pines, junipers, and yew, the Bindbole 
+remains evergreen year-­round, with several of the trees pro-
+ducing lovely red flowers in early spring. Older than the Shire 
+itself by most accounts, and exceedingly dark and tangled 
+at its heart, this wild wood is all that is left of a larger forest 
+that once ran all the way to the Hills of Evendim, beyond 
+the North Moors.
+Few Hobbit walking trails run under its spreading 
+branches, as more than a few tales speak of wolves lingering 
+in the shadows (though no wolves have been seen in the 
+Shire since the Fell Winter). More likely, they’re as real as 
+the Green Dragon rumours about wayward Big Folk from the 
+days of the King, or those talking of giants taller than trees 
+walking seven yards to a stride in the North Moors. Even if 
+these fanciful yarns are just that, the truth is that there are 
+no easy trails through the Bindbole.
+greenfields
+No exploration of the North­farthing would be complete with-
+out mention of Greenfields. Known throughout the Shire as 
+the place where Bandobras ‘Bullroarer’ Took drove back Golf-
+imbul and the Goblin horde from Mount Gram, it is bordered 
+on the south by the Norbourn, a watercourse descending 
+James Smith (Order #47812382)
+
+THE SHIRE
+30
+from the North Moors that joins the Brandy­wine just beyond 
+the borders of the East­farthing, and running into the North­
+farthing. It’s a vast land, mostly flat in between the two rivers, 
+rapidly rising as one turns north towards the Hills of Evendim.
+Here, visitors are likely to see small groups of Hobbit rabbit 
+hunters carrying bows. They spend long hours looking intently 
+at the ground for coney tracks, or kicking and stomping at their 
+hiding places. If one should start a conversation with any of 
+them, they would hear the same story about how the game of 
+golf was invented by the Bullroarer on that precise spot.
+hardbottle
+To most Hobbits, to call Hardbottle a remote village would 
+be an understatement — the only residents of the Shire 
+travelling so far are hunters, Bounders, and the members 
+of the Bracegirdle family and their numerous relatives. The 
+village itself stands at the confluence of the Norbourn and 
+the Brandy­wine rivers, and can be reached only by crossing 
+the Norbourn on a boat.
+This relative isolation hasn’t prevented the Bracegirdle 
+family from rising to a certain level of prominence in the 
+North­farthing. Known for their size (many family members 
+are said to be of great girth), outspoken nature, and supe-
+rior skill as masons, the Bracegirdle name is associated with 
+the building of every new home or Hobbit-­hole constructed 
+this side of the Water. In particular, Blanco Bracegirdle and 
+his son Bruno seem to have placed a brick or two in every 
+home in the Shire, with Blanco having brokered deals 
+with most mining businesses represented in Dwaling 
+in the last three decades.
+In recent years, Blanco Brace-
+girdle’s wife, Primrose, born 
+a Boffin, raised a flurry of 
+gossip with her decision to 
+leave Hardbottle and return 
+to her family estate in the 
+Yale — everyone in the 
+North­farthing knows the ‘real reason’ behind her decision 
+— from a bout of ‘wandering-­madness’, the discovery of the 
+secret cache of gold of her late father Otto, to the sudden 
+appearance of a disfiguring disease.
+long cleeve
+One can reach this little village on the edge of the North­
+farthing by following the course of the Water towards the 
+North Moors, well beyond Nobottle and Needlehole. Com-
+posed of a handful of houses along both sides of the river, 
+it is the home of the North-­Tooks, a smaller branch of the 
+renowned clan who claim direct descent from Bandobras 
+the Bullroarer himself, though there is a bit of a rivalry as to 
+whether or not they can rightfully say so. Every Took knows 
+that Bandobras left his home in the Tookland to settle in the 
+North­farthing only after the Battle of Greenfields, and that is 
+why they dispute the North-­Tooks appropriation of the Hob-
+bit hero. Fortunately, the dispute is kept friendly by holding 
+shared family reunions, which include “tests of heritage” — 
+nothing more than drinking contests, games of conkers, and 
+the obligatory golf tournament.
+the north moors
+This wide upland rises to meet the Hills of Evendim to the 
+North, and marks the northern borders of the Shire. It is an 
+area known for its heavy winter snowfalls and untamed wilder-
+ness, filled with scrub brush, heather, and the occasional 
+tree. All sorts of cautionary tales and rumours spring 
+out of the North Moors, and only the most hardened, 
+or most foolish, hunters dare venture this far north, 
+and they do it exclusively before the sun sets, for fear 
+of encountering wild beasts or things far worse.
+Where the Norbourn river flows out of the North 
+Moors stands what the Hobbits of the North­farthing 
+call ‘Kingsworthy’, a large stone house with a round tower, 
+believed to have been a hunting lodge at the time of the 
+Kings in Norbury. The origins of the site are probably more 
+prosaic, but the legend seems to have found confirmation 
+when a few years ago a hunter dug up the life-­size head of a 
+marble statue, representing what resembles a young prince 
+wearing a crown.
+oatbarton
+The Northway ends in the village of Oatbarton, a settlement 
+of modest size, surrounded by extensive oat fields. Its stone 
+houses seem to emerge from a veritable sea of long stalks, 
+bright green in Spring, golden by late summer. In winter, 
+James Smith (Order #47812382)
+
+The Northfarthing
+31
+heavy snows regularly blanket Oatbarton, and Hobbit chil-
+dren delight in re-­enacting the Battle of Greenfields using 
+snowballs and snowgoblins, which they promptly trounce with 
+the largest stick available.
+The village itself would be quite unassuming, if it wasn’t 
+for its great cobblestone courtyard, situated right in its heart. 
+Surrounded by granaries, wooden homes, barns, and sheds, 
+the courtyard becomes crowded at noon, when all farmhands 
+from the nearby fields gather to eat lunch — the simple, 
+hard-working folk of Oatbarton sit at long tables set up on 
+trestles, under tents and pavilions during the harvest season.
+The produce of the fields of Oatbarton is used by brewer-
+ies all over the Shire to make a particularly bitter beer, called 
+by some the ‘Dwarven Stout’. A drink that needs growing 
+accustomed to, it is favoured by travelling Dwarves, who don’t 
+seem to mind the sharper taste at all.
+VENTURE INTO THE NORTH MOORS
+Stories of what lies concealed and undiscovered along 
+these northern boundaries of the Shire range from hid-
+den camps of shadowy big folk who lurk and watch 
+Hobbit-­kind from a distance, to fanciful tales of the trees 
+themselves walking about in the light of day. To find out 
+what happens during a trip to the North Moors, the Lore­
+master can roll a Feat Die and consult the following table.
+NORTH MOORS ENCOUNTERS TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+A Wanderer’s 
+Campsite
+The Player-­heroes come upon a Man in travel-­worn clothing cooking a pair of rab-
+bits on a spit. There is a welcoming quality about him, in spite of his rugged look. He 
+offers the Player-­heroes a spot by the fire. If they accept, they hear him tell stories 
+about the lost realm of Arnor, the land of the High King…
+1
+Moaning 
+Trees
+An eerie and unnerving moan rings through a tiny grove of pine trees, as a cold wind 
+blows down from the hills to the north.
+2
+A Fissure in 
+the Ground
+The Player-­heroes stumble upon a great hole dug directly into the ground, large 
+enough for several Hobbits to enter. Inside, they find a skeleton of prodigious size, a 
+bear or a large Orc, and a crude club thrice their height.
+3
+A Crash and a 
+Laugh
+A large stony crash is heard echoing down from the north, followed by a distant, 
+booming laughter.
+4–7
+Ancient Relics
+The Player-heroes discover an old object, like a pitted and rusted sword or knife 
+blade, a brooch, a broken jar or pot, etc. It is mostly useless, but makes for a perfect 
+Mathom.
+8
+Followed 
+from the 
+Shadows
+The Player-­heroes get the uncomfortable sense they are being watched and fol-
+lowed. A cloaked figure seems to linger for an instant behind a far-­off tree, then dis-
+appears into the wilderness.
+9
+Wolf Carcass
+A large dead wolf is found, slain with arrows too large for Hobbit bows still stuck in 
+its side.
+10
+Uprooted 
+Tree
+Though the ground looks otherwise undisturbed, there are signs that a tree has been 
+ripped from the ground, roots and all. Large depressions in the soil can be seen trail-
+ing off to the north and west.
+Wrathful 
+Spirit
+A ghastly spirit rises out of a darkened shadow to plague the Player-­heroes, the hiss 
+of “Angmar” on its spectral lips as it passes through them and leaves a chill far deeper 
+in their bones than any winter ever could. They will have dark dreams about it for a 
+few days.
+James Smith (Order #47812382)
+
+THE SHIRE
+32
+James Smith (Order #47812382)
+
+The Eastfarthing
+33
+the eastfarthing
+The Hobbits of that quarter, the Eastfarthing, were rather large  
+and heavy-legged, and they wore dwarf-boots in muddy weather.
+While not quite the largest of the Four Farthings, the East­
+farthing is most certainly the oldest, as it is this land that the 
+founders of the Shire encountered first, when they crossed 
+the Bridge of Stonebows long ago. From the Three-­Farthing 
+Stone in the west to the Brandywine Bridge in the east, the 
+quarter is divided in two by the East Road and the course of 
+the Water. The northern half is an upland, dominated in its 
+middle by stony hills, and slowly rising towards the North 
+Moors. The southern region is wilder, crossed by innumer-
+able streams and brooks, sometimes leading to vast patches 
+of marshland. The main townships of the East­farthing are 
+Frogmorton and Whitfurrows, along the East Road.
+Many Hobbits living in this part of the Shire bear some 
+distinct physical features, when compared with their neigh-
+bours. They are generally heavier in build, and some even 
+sport a trace of beard on their chin (no Hobbit living else-
+where ever displayed anything so uncanny). Esteemed Hobbit 
+‘historians’ attribute these peculiarities to the fact that the 
+ancestors of the Hobbits of the South­farthing belonged to 
+a southerly branch of Hobbit-­kind, where most of the other 
+first settlers came from the West.
+the brandywine
+Running for uncounted leagues from its source in Lake Even-
+dim to its faraway mouth at the sea, the Brandywine River 
+serves as the eastern border of the Shire. With the founding 
+of Buckland, the river also demarcates the division between 
+a land inhabited by proper Hobbits, and the wrong side of 
+the river, where the Bucklanders dwell. Whether east or west, 
+the watercourse occupies a prominent place in the lives of 
+a great many Hobbits. Many boats, both fishing and leisure, 
+can be seen crossing it, or moored along its banks, especially 
+on the eastern side.
+The main crossing is the Brandywine Bridge, also called 
+the Bridge of Stonebows, a marvel leaping across the river 
+in three graceful arcs. No Hobbit can recall the days when 
+it was built, but the Shire-­folk keep it in good repair as they 
+were instructed to do so at the time of the Northern King-
+dom. The bridge is wide and strong, allowing carts, ponies, 
+and wagons to easily cross.
+The other crossing, though less used and less trusted, is 
+the Bucklebury Ferry, found approximately ten miles down-
+river, in the northern part of the Marish. This large, flat boat 
+can be reached via a narrow lane off the Causeway running 
+parallel to the Brandywine, and makes its mooring on the 
+opposite bank in the heart of Buckland, near the village for 
+which it is named. Though tended by a ferryman by day, no 
+one remains in service after nightfall, and it is seldom used 
+at such times for fear of some poor Hobbit slipping over its 
+edge and plunging into the waters of the Brandywine.
+GIRDLEY ISLAND
+Ten miles north of the Bridge of Stonebows, the 
+Brandywine River bifurcates around a narrow 
+island, about two mile in length. Called Girdley 
+Island, it is covered with wild shrubs and low trees, 
+and is rumoured to be a haunted place. Those few 
+who have moored their boats there and made 
+their way through the vegetation claim to have 
+heard scratching noises or stirrings beneath their 
+feet. As a consequence, the island is abandoned to 
+its waterfowl and wild vegetation, save for some 
+brave Bucklander or foolish East­farthing youth 
+who visits it on a dare to test their valour.
+Unbeknownst to everyone in the Shire, the 
+secret of Girdley Island lies not in cursed spir-
+its, but in hidden guardians. In the middle of the 
+island is a secret refuge, built in recent years by 
+the Rangers of the North. It is a small fortification, 
+mostly underground, concealed in a great copse 
+of trees. From here, the Rangers use their small, 
+flat-­bottomed boats to move swiftly up and down 
+the Brandywine, easily moving as far north as Lake 
+Evendim or south to Sarn Ford.
+James Smith (Order #47812382)
+
+THE SHIRE
+34
+DWARVES ON THE ROAD
+Much to the Hobbits’ consternation, Dwarves make reg-
+ular use of the East Road, travelling to and from their 
+home in the Blue Mountains far to the west of the Shire. 
+It is not uncommon for local travellers to encounter these 
+bearded wayfarers on their errands to foreign parts as 
+they pass through the heart of the Shire.
+When the Player-­heroes are on the East Road, the 
+Lore­master can roll a Feat Die to determine if an encoun-
+ter occurs.
+EAST ROAD ENCOUNTERS TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+Merry 
+Merchant
+A particularly jovial Dwarf is returning to the Blue Mountains after a long trip from the 
+Lonely Mountain. Delighted and glad to soon be home, he gives each Player-hero a 
+gift, claiming that he is following the tradition of the locals and celebrating his own 
+birthday! The gifts are nothing less than fine, and indeed, magical, toys from the mar-
+kets of Dale!
+1–3
+No Encounter
+No special encounters are had.
+4
+Boasting 
+Brewers
+The Player-­heroes meet two Dwarven brewers from the Blue Mountains, burdened 
+with beer-­barrels bought at the Golden Perch. They claim to have discovered the 
+secret of the ‘best beer in the Shire’, but appear to have sampled their wares a bit 
+too much.
+5
+Renowned 
+Relatives
+A lone Dwarf stops the Player-­heroes and asks for directions to Bag End, claiming to 
+be a distant relation of one of Thorin’s Company.
+6
+Sullen Smith
+A visibly angry Dwarven blacksmith is hauling ore from the mines at Scary, upset and 
+irritated at what he calls a “cross deal”, and shoots the Player-­heroes a mean look as 
+he passes.
+7
+Bent Blades
+Shouldering a mighty wood axe and leading a pack mule, a Dwarf claims he tried to 
+chop some wood from the Old Forest on his way here, but that the trees made groan-
+ing noises and dulled the edge of his axe.
+8
+A Song for a 
+Song
+A Dwarf is strumming on a harp as he sings to himself. He offers to teach one of the 
+Player-­heroes a Dwarven song in return for a local one. If obliged, he kindly gives the 
+character a silver tin whistle engraved with Dwarvish runes as a thank you.
+9
+ A Nice Nap
+A Dwarf has fallen asleep on the road, fat and content. A cooked sausage is still held 
+in his meaty fist. If disturbed, he awakens with a start and asks for directions to the 
+nearest inn.
+10
+Beleaguered 
+Beards
+The Player-­heroes spot a group of Hobbit children running down the East Road, 
+their leader holding a tuft of hair in their fist. Behind them comes a lumbering Dwarf, 
+shouting and holding the end of his beard.
+Appalling 
+Accusations
+A particularly cantankerous Dwarf halts one of the Player-­heroes as they pass, accus-
+ing them of theft and mistaking the befuddled travellers for someone else. The 
+Player-­heroes will need to do some fast talking if they hope to avoid an awkward 
+confrontation.
+James Smith (Order #47812382)
+
+The Eastfarthing
+35
+bridgefields
+Bridgefields is the name of a long stretch of fertile land extend-
+ing for about three leagues west of the Brandywine Bridge, and 
+likely named in reference to it. The most prominent village of 
+the district is certainly Whitfurrows, the first township of the 
+Shire one encounters when travelling west along the East Road.
+WHITFURROWS AND BUDGEFORD
+Acting as an eastern counter to Waymeet in the West­farthing, 
+Whitfurrows lays at the crossroads of the East Road and the 
+winding path that leads north to the Brockenbores and Scary. 
+Hobbits from across the East­farthing come to Whitfurrows 
+to do a bit of brisk trade, as do Dwarves going west towards 
+the Blue Mountains — though they get a bit of a cold shoul-
+der from most locals. In years past, even a few Bree-­Hobbits 
+showed up to trade with the Shire-­Folk, but those days have 
+long gone by. The district includes to the north the com-
+munity of Budgeford, a village built upon both banks of the 
+Water. Budgeford is the seat of the Bolger clan, an ancient 
+family with a long tradition of high-­sounding names.
+deephallow
+The village of Deephallow is nestled near the corner where 
+the Shirebourn meets the Brandywine, just north of the Over-
+bourn Marshes. It is reached by taking the road that branches 
+out from the East Road near the Brandywine Bridge and by 
+following it to its very end.
+The Hobbits that make their homes here have a repu-
+tation as a cantankerous lot, perhaps due to their feud with 
+the Buckland Hobbits of Haysend, on the other side of the 
+Brandywine (theirs is a Hobbitish rivalry, expressed mainly in 
+words and surly looks). They seem to have less love for mer-
+riment than other Hobbits, and most even bar their doors 
+at night. This lesson is one they undoubtedly took up in a 
+manner similar to their Buckland rivals, though if reminded 
+of this they will vehemently deny even this most tenuous con-
+nection. Those rare visitors that travel so far south are given 
+a cold reception, though this is not due to malice — the 
+Hobbits of Deephallow seem to know better than their west-
+ern counterparts what lies just beyond their borders, and are 
+reluctant to have such dangers fall upon their neighbours.
+FORGOTTEN FOXGLOVE
+In a time when the rivalry between the folk of Deephallow and 
+that of Haysend ran deeper, there lived a Hobbit girl whose 
+name has been forgotten. She fell in love with a Hobbit of 
+Haysend, and the enmity between their families kept them 
+forever apart, until she was driven mad by sorrow and walked 
+into the Overbourn Marshes and was never seen again. Some 
+among the more superstitious folk of Deephallow claim that 
+she still lingers there, singing a lament for her one true love 
+in hopes of luring him — or any young Hobbit foolish enough 
+to be enchanted by her voice — into her arms and to a watery 
+grave. Known by the locals as the Forgotten Foxglove, she wan-
+ders the Overbourn Marshes, her gaze forever cast downward.
+frogmorton
+Travelling out from the Three-­Farthing Stone along the East 
+Road, one will first come to the village of Frogmorton on 
+the southern banks of the Water as it splits in two flowing 
+westward, creating a large eyot. Named for the croaking 
+chorus that fills the air on summer nights, this community 
+marks the halfway point between Hobbiton and the Bran-
+dywine Bridge. Frogmorton is perhaps most well-­known for 
+the Floating Log, the first good inn one encounters on the 
+East Road heading west (the establishments of Whitfurrows 
+and Budgeford are not worth mentioning). A fine establish-
+ment certainly, if only its proprietor Juniper Broadbelt would 
+give up her family’s endless quest to somehow prepare frog 
+legs as a proper meal.
+James Smith (Order #47812382)
+
+THE SHIRE
+36
+the hills of scary
+Going north on the road from Budgeford, one travels towards 
+a range of hills that rises almost along the border with the 
+North­farthing. Against the side of the hills one finds first the 
+village of Scary, then the Brockebores to the west, and on the 
+other side, the township of Dwaling. It is under the hills of 
+Scary that the first settlers found lodes of iron ore, and it is 
+from here that the Shire-­Hobbits still extract the mineral and 
+quarry the stone required to build their many houses above 
+ground — the number of tunnels dug under the hills, from 
+the Brockenbores to the quarries at Scary, are an indication 
+of this centuries-­old practice.
+A bit too dour for the likes of their merrier cousins to the 
+south, the Scary Hobbits and those of the Brockenbores rarely 
+venture into the heart of the East­farthing. Most seem content 
+to stick to their own business, undisturbed, a very Dwarvish 
+attitude for a Hobbit to display. The Hobbits of Dwaling are 
+friendlier and more open towards strangers than their neigh-
+bours, and they often act as intermediaries for the mining folk 
+of the hills — they broker deals for them, and provide them 
+with all they need to continue their work without distractions.
+THE BROCKENBORES
+Hobbits are natural tunnellers, and have no fear of the under-
+ground. In recent years though, some miners from the Brocken-
+bores have started to suffer from a coughing sickness and mal-
+ady of the spirit that slowly drains their strength. This is no brief 
+thing, and seems to take years before the condition takes hold, 
+but no one has been able to find the source of this strange illness.
+Some say it is the growing greed of the Hobbit brokers 
+of Dwaling, driving the miners to delve ever deeper into cav-
+erns never before explored — and never meant to be opened. 
+Others claim that the skull of Golfimbul the Goblin, which lay 
+in a rabbit hole since time out of mind, has slowly worked its 
+way deep into the soil and begun to poison the land. A few 
+more cynical Hobbits claim it is simply the newest generation 
+of miners trying to find an excuse to do less work. Whatever 
+the source, the mining officials in Dwaling have finally decreed 
+that no Hobbits be in the mines after dark, and that everyone 
+who goes into the tunnels stay in pairs for safety.
+the marish
+The home of the Oldbuck family who famously migrated to 
+the other side of the Brandywine river long ago, the Marish 
+is a fenland that saw the first house-­dwellers of the Shire. 
+When they found it impossible to dig proper Hobbit-­holes 
+in the soggy ground of the region, the original settlers of the 
+area started building farms, barns, and sheds above ground. 
+This tradition continues to this day, and many farms dotting 
+the area are stout buildings built of brick and with thatched 
+roofs. The road traversing the Marish is peculiar in itself, as 
+it is a causeway, a raised road built to carry travellers above 
+the watery ground.
+RUSHEY
+The tiny hamlet of Rushey is one of the main settlements of 
+the Marish, the other one being the larger village of Stock. 
+Rushey stands upon a low hill, and houses a small number 
+of families. The locals pride themselves on their harvests of 
+cabbages and rhubarb, as well as their ability to draw bog iron 
+from the surrounding swamps day and night — sometimes 
+even working by lantern light. They trade their ore in Stock 
+and the Bridgefields, and with the people of Deephallow, and 
+even across the water in Buckland.
+PALE, COLD LIGHTS
+The Hobbits of Rushey aren’t ones to speak of their troubles 
+to outsiders. But in recent days, some of the locals have been 
+reluctant to go into the surrounding marshlands in search of 
+bog iron — especially after the sun goes down. Some fear has 
+set upon them, and whispers of strange, scintillating lights 
+that dance between the reeds and carry off wayward Hobbits 
+into the marsh, never to return, are starting to be heard over 
+drinks as far north as Stock and even over the Brandywine in 
+Bucklebury.
+Travellers who fail an EXPLORE roll while moving through 
+the reeds and swamps around Rushey at night might encoun-
+ter these flickering lights, and be drawn into a dreamy haze as 
+they become completely lost in the marsh. Snapping out of it 
+several hours later, they are overcome by an unnatural fear and 
+must make a VALOUR roll to regain their composure before they 
+can find their way back to safer ground.
+stock
+The town of Stock is certainly the busiest village in the Marish, 
+if not the entire South­farthing. It can be reached easily, by 
+following the Stock Road out of Tuckborough, by slipping out 
+of Woodhall following the Stock-­brook, or simply by walking 
+on the causeway. This bustling community is just as full of life 
+as Hobbiton or Michel Delving, and has the best fish market 
+James Smith (Order #47812382)
+
+The Eastfarthing
+37
+in all the Shire. Fresh catch can be found almost every day of 
+the week, plucked right out of the Brandywine or the Stock-­
+brook. But a good part of the popularity that Stock enjoys 
+must be attributed to the Golden Perch, the inn known for 
+the best beer served in the East­farthing (of no less repute is 
+its plate of fish and chips). Here, it is not uncommon to find 
+the occasional thirsty Took, who has come all the way from 
+Tookland on a beer-­tasting walk.
+willowbottom
+Willowbottom lies at the southern edge of the East­farthing, in 
+the deep valley cut by the Thistle Brook as it flows out of the 
+Woody End. Populated by a handful of families boasting many 
+fishermen and the occasional hunter and woodsman, Willow-
+bottom is connected to Deephallow by means of an easterly 
+road. The locals fish from the waters of the Thistle Brook and 
+the near course of the Shirebourn, and hunt along the edges 
+of the Woody End. They build simple wooden homes, and 
+rarely venture outside their vicinity, except to trade with the 
+Hobbits of Deephallow. It has been probably a century since 
+someone from Willowbottom has ventured outside the East­
+farthing — at least that’s what they say in Stock.
+woody end
+Though this great upland forest of oaks and beeches, white-
+beams and rowans, begins on the edges of Pincup in the 
+Green Hills, its heart rests in the East­farthing. Here, foxes, 
+badgers, and wild rabbits mingle with finches, starlings, 
+and robins. From all the noise they make in the spring-
+time among the great thicket of wood, one would suspect 
+they are constantly gossiping with one another. It is not 
+uncommon for Hobbits from the Yale to go on picnics 
+along its edge. Indeed, the Stock Road from Tuckborough 
+runs under its northern boughs on its eastward course, and 
+both the River Shirebourn and the Thistle-­Brook begin 
+there before descending south. But apart from these infre-
+quent intrusions, the Woody End can be considered to be 
+sparsely populated at best, if not outright uninhabited. In 
+autumn, the Woody End takes on a blazing golden hue, and 
+the busy community of beasts and birds falls silent. By the 
+time the first snows begin to fall, the hearth smoke trickling 
+up from its eastern end leads travellers to the welcoming 
+fires of Woodhall.
+WOODHALL
+As one would suspect from the name, the village of Woodhall 
+sits nestled in a tiny valley at the northeastern edge of the 
+Woody End. It’s a tiny community of woodsmen, hunters, 
+and farmers, enjoying the isolation and fresh air of their 
+wild corner of the Shire. Despite the remoteness of the 
+place, the local bilberry cake is a popular dish in the East­
+farthing, and is served as far away as the inns at Stock and 
+Frogmorton.
+A famous personality from Woodhall is the pipe-­maker 
+known as Old Rosefield, an artisan who has carved the finest 
+briar smoking pipes in all the Shire for nearly seventy years. 
+They fetch quite a good price on the rare occasion they appear 
+in the markets of Whitfurrows. Although only a few people 
+know it, in his house, Old Rosefield keeps an incredible col-
+lection of pipes he acquired from strange and foreign lands 
+over the decades (in addition to a precious selection of those 
+he has carved himself in his lifetime). Some of the older and 
+most precious pieces are said to be of Dwarf-­make, while 
+another is even rumoured to have been crafted in a great 
+Wizard’s tower far to the south. Such strange creations must 
+undoubtedly have equally strange enchantments upon them, 
+and Rosefield is said to give them away to those who perform 
+a great service to the people of Woodhall. On rare occasions, 
+he will even trade them with those who offer a piece of fine 
+craftsmanship in return.
+THINGS TO DO IN STOCK
+Though not as prestigious as Michel Delving, or 
+Hobbiton, Stock is quite a robust community. 
+Player-­heroes can find a surprising number of 
+things to do given its large population, active 
+community of fishermen, and the reputation of 
+the Golden Perch that draws visitors from all the 
+Four Farthings.
+Visitors to Stock might find themselves 
+drawn into one of its many regular fishing tour-
+naments, enjoying a fine meal of fish and chips 
+at the Golden Perch while they hear the latest 
+tall tales out of Buckland and the Old Forest, or 
+trading stories with a Dwarven traveller taking 
+a break for the night. Player-­heroes might be 
+hired to carry a load of salted trout to Hobbiton 
+or even as far as Michel Delving, or even tasked 
+by a curious local with making an expedition to 
+far off Bree to see if all the foolish tales from 
+that town are true.
+James Smith (Order #47812382)
+
+THE SHIRE
+38
+WANDERING ELVES
+Before Hobbits took root in the Shire, great forests covered 
+the land, and Elves used to roam freely across the area. 
+Today, one can meet them sometimes in the Woody End, as 
+they wander on paths that are seldom trodden by Mortals.
+The Lore­master can roll a Feat Die to determine 
+whether or not the Player-­heroes encounter such a trav-
+eller, should they find themselves beneath the eaves of 
+the Woody End under bright-­burning stars.
+WOODY END ENCOUNTERS TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+An Unexpected 
+Guest
+The Player-­heroes have come upon a merry gathering of Elves and are invited to join 
+them for an evening of fine food and lovely singing. They wake up the next morning 
+filled with an invigorating zest (they each recover one point of Hope).
+1–7
+No Encounter
+No special encounters are had.
+8
+Sleeping Fairy
+A fox behaving curiously invites the Player-­heroes to follow her. She leads them to what 
+seems to be a fair Elf-­maiden lying unconscious on the ground. If they help her with a 
+HEALING roll, she wakes up, thanks them, and then disappears into the forest. From that 
+moment on, when they are in the Woody End they never encounter bad weather.
+9
+Dancing Stars
+Dancing lights dart to and fro in the Woody End, and a merry laughter is heard, as if 
+someone were playing a prank. A tinkling of bells is heard, and then a warm breeze 
+and the scent of flowers fills the air.
+10
+Tales from 
+the Trees
+Hidden among trees, a few Elves call to Hobbits unknowingly passing by. After polite 
+greetings, the Elves ask about the goings-­on in the Shire before offering a tale of 
+their people and proceeding on their journey.
+Wounded 
+by Sorrow
+A sad Elf travels alone. He sees the Hobbits, smiles without mirth, then gazes to the 
+stars and vanishes into the darkness. The sight of one so bright and beautiful laid low 
+by the weight of the world’s troubles leaves a stain on the heart of the Player-­heroes, 
+causing them to lose 1 Hope.
+James Smith (Order #47812382)
+
+The Eastfarthing
+39
+the yale
+The lowland region known as the Yale lies to the north of 
+the Woody End and south of the Bridgefields district. The 
+ancestral seat of the Boffin family, the Yale has no prominent 
+village or township, but is instead dotted by many farms. For 
+as long as any can recall, its inhabitants have tended fields 
+of corn, cabbage, wheat, and many other crops. In recent 
+generations, some among them have even taken to tending 
+wandering flocks of sheep and keeping dairy cattle that nib-
+ble the grass of the long fields surrounding their homeland. 
+This pleases the folk of the East­farthing to no end, and con-
+tributes to many a fine table kept in the region.
+THE BLACK WOLF OF WOODY END
+Children of the Yale are taught from an early age that if they’re 
+naughty they’ll get more than a light supper. The worst punish-
+ment that any child in the East­farthing could possibly imagine 
+is to be taken by the Black Wolf of Woody End. Locals say it 
+is descended from one of the terrible beasts that came down 
+during the Fell Winter. Now it lingers in the deepest part of the 
+forest, watching for wayward children, and leaping out from 
+the darkness to snatch them away and devour them.
+With fur as black as night and eyes as red as fire, it only 
+comes out from its secret den at night to stalk its prey. It is 
+said to have a particular fondness for Hobbit children, espe-
+cially naughty ones — or so the gaffers and gammers 
+say. Grown-­ups know the Black Wolf to be nothing 
+more than balderdash, but in recent years, adven-
+turous souls who’ve gone off into the Woody End 
+in search of Elves at sunset claim to have seen 
+gleaming red eyes staring at them from the 
+long shadows of the fading day. More than 
+one child, and even a tween or two, has 
+come running from the forest stammering 
+and spluttering about a low, rumbling 
+growl and the sight of a pair of fiery eyes 
+glowing in the darkness.
+The hysteria has gotten to be a bit 
+much for the people of the Yale and calls 
+have rung out for a Bounder to make a 
+proper investigation. The Bounders are not 
+very inclined to investigate, and it may fall to more 
+adventurous locals to get to the bottom of things.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+THE SHIRE
+42
+buckland
+… a thickly inhabited strip between the river and the Old Forest, a sort of colony from the Shire. 
+Its chief village was Bucklebury, clustering in the banks and slopes behind Brandy Hall.
+Brandywine River and travelled almost to the edge of the Old 
+Forest, where he stopped to set down stakes. He even went so 
+far as to rename himself Gorhendad Brandybuck and built 
+the great complex of smials we now call Brandy Hall.
+These days, Buckland has a reputation for all kinds of odd-
+ities that range from river-­boating and even river-­swimming 
+Hobbits, to legends that whisper of hateful trees that move 
+on their own beyond the High Hay. Though they might seem 
+strange to most Hobbits residing elsewhere, Bucklanders are 
+a proper folk, after their own fashion.
+bucklebury and brandy hall
+Bucklebury is quite a bustling little village, serving the heart 
+of Buckland with its ferry. Brandybucks of all stripes and their 
+closest kin live around here, fishing along the banks of the 
+Brandywine, tending chickens, and growing crops like any 
+other Hobbits. Buck Hill rises up at its very heart — it is a 
+large mound covered in green grass and wildflowers in both 
+spring and summer, and the seat of Brandy Hall, where the 
+Master of Buckland rules over his numerous relations.
+Regardless of the day or season, one hundred Brandy-
+bucks seem to be ever present, moving along the deep-­delved 
+tunnels of Brandy Hall, and there’s always a collection of kin-
+folk setting to work on new passages and chambers to make 
+more room for the growing family. As it is now, Brandy Hall 
+has three large front doors, several secondary doors, and 
+a hundred windows, all opening on the sides of Buck Hill. 
+Each door is fitted with a stout lock, an enduring habit from 
+the days of Buckland’s founding as a protection against the 
+dangers of the nearby Old Forest.
+crickhollow
+The biggest news out of Buckland in recent years came last 
+spring when a young gentlehobbit by the name of Rollo Bof-
+fin came all the way from the West­farthing and built himself 
+a small but homely house. For his new residence he chose 
+Crickhollow, a pleasant corner a few miles north of Bucklebury. 
+Taking little heed of the advice of locals, Rollo has built his 
+home closer to the High Hay and the Old Forest than is con-
+sidered proper, much to the consternation of his neighbours.
+No Hobbit east of the Brandywine would dare be so outra-
+geous as to call Buckland the fifth Farthing of the Shire, but 
+by all reasonable conclusion that is what it is. It was founded 
+over six hundred years ago, when Gorhendad Oldbuck 
+decided the Shire was getting too crowded for his liking. The 
+enterprising Hobbit took himself and his relations over the 
+James Smith (Order #47812382)
+
+Buckland
+43
+haysend
+A small village, little more than an outpost, stands at the 
+southern edge of the High Hay, where the Withywindle flows 
+out the Old Forest to join the Brandywine. Only the most 
+hardened loners of Buckland live here, with the Old Forest 
+almost at their doorsteps. Caught between the river bend 
+and the trees, they constantly drive away curious visitors with 
+their dour stories and cold demeanour. The folk of Haysend 
+seem to have a particular dislike for the Hobbits of Deephal-
+low, with whom they are always arguing over fishing rights 
+and fair trading prices.
+FISHING COMPETITION
+The disagreements between the Hobbits of Haysend and Deep-
+hallow over fishing rights may finally come to an end. The peo-
+ple of both villages have agreed to hold a fishing competition! 
+Whoever wins will enjoy exclusive fishing rights over the tract 
+of the Brandywine dividing the two settlements for one full 
+year. Both villages will choose a fisherman champion — who-
+ever pulls the most fish out of those coveted waters from dawn 
+till dusk will be declared the winner.
+But nothing is ever that simple when it comes to settling 
+such disputes. Neither village trusts the other, so they’re both 
+in search of impartial judges for the contest. The folk of Deep-
+hallow don’t trust anyone from Buckland, and the Haysend 
+locals don’t want any Shire-­Hobbit.
+The Player-­heroes may find themselves in this unlucky role if 
+they get drawn into local politics. Judging the competition will 
+be an exercise in frustration, as members of both communities 
+argue with one another over everything, from the proper bait, 
+the exact time for sunrise and sunset, whether the winning boat 
+should be determined by quantity or weight of the fish caught, 
+or any other tiny detail they can think of. This can require any 
+number of AWARENESS, HUNTING, or INSIGHT rolls, depending 
+on what the character is judging, and no matter who ends up 
+being the victor, the judges will surely be accused of having 
+cheated or even having been bribed by the winners, and noth-
+ing will truly be settled!
+OLD BROADBELT
+The current Master of Buckland is Gorbadoc Brandybuck, 
+or Old Broadbelt as he is known by many — on account 
+of his ample waistline and his considerable age. He has 
+shown his good character by serving as a shrewd and 
+stout patriarch over both kin and land for fifty years now. 
+In spite of his stiff demeanour, he’s shown nothing but 
+kindness to his own kin, even when his daughter Prim-
+ula went and became engaged to Drogo Baggins out of 
+Hobbiton. A gaffer’s wisdom keeps him well aware of any 
+mischief which his relations get up to, whether causing 
+trouble or planning some foolish expedition into the Old 
+Forest. Though he was once a tween himself, and loves 
+to recount to his younger relations the stories of his days 
+as a reckless youth, Gorbadoc is quick to undercut such 
+tales with reminders that this mischievousness come at a 
+cost, and one must always keep a keen eye and a sharp 
+mind in all deeds.
+James Smith (Order #47812382)
+
+THE SHIRE
+44
+BRANDY HALL BALDERDASH
+Old Gorbadoc keeps a fine table, full of hearty fare and 
+endless talk. Anyone who sits down for a meal at Brandy 
+Hall is likely to hear a story or two about the strange 
+goings-­on in the Old Forest just beyond the Hedge.
+The Lore­master can roll a Feat Die to see what odd 
+tale is the topic of the night.
+BRANDY HALL TALK TABLE
+FEAT DIE 
+ROLL
+RESULT
+“I heard there’s an Elf-­maiden that lives in the Old Forest, singing songs upon the banks of the Withy-
+windle and walking upon water lilies. They say that if you brew tea from those lilies she’s walked upon 
+you can speak the fairy tongue as if you were born to it!”
+1
+“I tried to tell that Rollo Boffin fellow that I saw a black dog prowling about his garden last night after 
+coming straight out of a thicket in the High Hay, but he waved me off as if I was mad!”
+2
+“A Dwarf I tell you! I saw a Dwarf dancing and singing in the forest as clearly as I see you now! Speaking 
+some kind of nonsense, he was, too.”
+3
+“Mad Baggins didn’t find any treasure in some far-­off Dwarf-­hold. He snuck away and got lost in the 
+Old Forest for nigh on a year. Drove him right mad it did, and all his stories we’ve heard these past 
+years are nothing but fairy stories and idle gossip.”
+4
+“Hobbits I tell you! Living right there in the heart of the Old Forest and right upon the banks of the 
+Withywindle. No, I ain’t got no proof, but they’ve got a mischievous light in their eyes and seem a bit 
+too merry for ones to be living in so dour a place. Never you mind how much I’ve had from Gorba-
+doc’s personal brew!”
+5
+“I say ain’t no strangeness in that forest except the ones put there by that Wizard Gandalf. I’d bet my 
+gaffer’s soup spoon he’s got some secret tower with all manner of magic leaking through the stone 
+and twisting the forest.”
+6
+“Wrapped right around my ankle it was, as strong as a fist that root! I took my axe to it and wouldn’t 
+you know, it recoiled like a serpent waking from a summer nap. I can’t rightly say if the trees in that 
+forest get up and walk as some would have it, but I know what I saw with my own two eyes.”
+7
+“Been slippin’ into that wood since I was a tween and I tell you, I ain't never seen no path that runs that 
+way. Ain’t no roads nor game trails that close up behind a Hobbit as he walks. Not outside of tavern 
+tales and children’s stories.”
+8
+ “I heard it speak as clear as I hear you! It told me to leave. Yes, I know the branch full of leaves told me 
+to leave, but you mind what you’re laughing about when you know nothing.”
+9
+“So there I was, as lost as I could be. I knew if I didn’t get back before nightfall, I was in for trouble, and 
+I’m not afraid to say I called out for help — but the air itself ate my words right up. But wouldn’t you 
+know it? A badger came plodding out of the brush as pleased as punch, and looked me in the eye as if 
+he understood every word I said. Led me home he did, but I never saw him again.”
+10
+“That branch tried to reach right over the Hedge, and snatch poor Marybelle clean off her feet and into 
+the forest. I saw it myself, but by the time the Hedge guard came over, it seemed like it was nothing 
+but wind and the drooping of a low branch.”
+“Been twenty years since it took her, my dear Daisy May. We walked hand-­in-­hand into that cursed 
+wood. We were adventurous back in those days. Got down on my knee in front of the biggest tree of 
+the wood. It was like a dream, slow and hazy. Last thing I heard before we both fell into that slumber 
+was her saying ‘yes,’ but when I woke up she was gone, and I swear that tree looked bigger than it did 
+when I first went out.”
+James Smith (Order #47812382)
+
+Buckland
+45
+BREREDON
+Often forgotten or even wilfully ignored by even the Hobbits 
+of Buckland for their willingness to dwell beyond the High 
+Hay, there is a tiny community of fishermen somewhere just 
+beyond the Hedge inside the borders of Old Forest itself. 
+Known as Breredon, it stands near a small landing on the 
+Withywindle, protected by a barrier they call the Grindwall 
+that extends into the water.
+The folk of Breredon, when encountered at all by other 
+Hobbits, are a fey lot even by Buckland standards. They 
+are prodigious smokers, and have a particular fondness for 
+rhymes and riddles, which even they do not recall from where 
+they learned — though these nonsense songs have been 
+passed down for as long as any can remember and new ones 
+even spring unbidden into the minds of Breredon Hobbit 
+children from time to time. The Hobbits in Haysend claim 
+to hear these merry and foolish songs coming up over the 
+High Hay on warm summer nights — if you can pull such a 
+tale out of those ill-­tempered folks.
+STRANGE SONGS
+Visitors staying the night in Haysend, or in Breredon itself, 
+may get to hear one or two of the outlandish songs sung 
+by those strange Old Forest dwellers.
+The Lore­master can roll a Feat Die to see which songs 
+are sung on such a night.
+BREREDON TALES TABLE
+FEAT DIE 
+ROLL
+RESULT
+“Saw the golden lady I did, walking upon the Withy waters. As fair as morning dew she was, a River and 
+her daughter.”
+1
+“Lights they dance, from Rushey to the Forests of Cardolan. Spirits in the Woodlands, Ghosts of 
+­Northern Kings of Man.”
+2
+“Whisper not words and threats to Old Man Willow. Unless blue your jacket be, and your boots 
+be yellow.”
+3
+“Badger-­Brock is a friend of mine! Treat him well, treat him kind!”
+4
+“Wandering dog, he’s not returned! Blackened beast in bonfire burned!”
+5
+“Hear you not the song of the Master and his River-­Wife? Take his gifted lilies or instead take strife!”
+6
+“Trespass, trespass, walker in the wood. Hateful trees, and harmful wood. Raise no axe and no secrets 
+tell, lest you be forgotten, and you be felled.”
+7
+“In the house, in the house the Master waits. Greet him kindly at his gates. Remain awake if you are able, 
+until you sit at Orald’s table!”
+8
+“Gold be the berry unplucked from the tree, dancing upon the lilies fairest among the free.”
+9
+“Old songs are foolish, yes it’s true. But such was power when the world was new.”
+10
+“Blades in barrows, deathless kings entombed, Elf-­Lord spoke Black Captain’s doom.”
+“Go not, go not, for trees remember! First to burn in blackened embers!”
+James Smith (Order #47812382)
+
+THE SHIRE
+46
+the high hay
+The High Hay is a thick hedge rising thrice the height of a 
+Hobbit, and running for the length of the eastern border 
+of Buckland, almost ten leagues from the East Road in the 
+North, to the village of Haysend in the south. If you listen to 
+those living in Buckland, the High Hay is the true border of 
+the Shire, a claim disputed only by those traditionalists who 
+live west of the Brandywine. Three openings allow passage to 
+the other side — the North Gate, leading to the East Road 
+and guarded day and night, a private tunnel near Crickhollow 
+used by members of the Brandybuck clan, and a southern gate 
+opening in the vicinity of the village of Haysend.
+Old lore holds that the Hedge (another name for the 
+High Hay) was planted by order of Gorhendad Oldbuck 
+upon the very day he claimed the surrounding land as his 
+own. According to the stories, the trees of the Old Forest 
+itself rose up in revolt years later, enraged at having a border 
+forced upon them. They leaned over the Hedge, threatening 
+to smash through it, and were driven back only when the 
+Buckland Hobbits burnt hundreds of trees, feeding a bonfire 
+that went on for days on end, gaining them the hostility of 
+the Forest. A glade opens on the spot where that fire raged, 
+as no trees will grow near it.
+The Hobbits of Buckland maintain a constant vigilance 
+over the High Hay. Guards armed with axes as well as flint and 
+tinder walk its edge, planting fresh seeds and cutting away way-
+ward vines to ensure that the Old Forest remains in its place.
+newbury
+Nestled just a few miles north of Bucklebury and cradled 
+along the edge of the Old Forest, the village of Newbury is 
+considered a recent addition to the region, even if its founda-
+tion goes back to a time no one in Buckland can remember. 
+With no Bounders crossing the Brandywine and the shadow 
+of the Old Forest on their doorstep, many of the folk in 
+Newbury keep a wary eye on the darkness 
+when the night comes, tending to the Hedge 
+and even making rare expeditions into the 
+woodland proper. Still, they always return 
+before nightfall, and there’s never been a 
+tale of one going without a proper bow and 
+quiver along with their sturdy walking stick. 
+More than one has even gone in with an axe 
+at their belt!
+The locals that gather at Hugo’s Gruff, a 
+tiny local inn of comparatively poor quality 
+to those found in the Shire, regularly hear 
+tales of unnatural goings on in the Old 
+Forest, and on windy autumn nights, many 
+locals claim that they can hear baleful noises 
+echoing up from over the High Hay.
+standelf
+Standelf is found at the end of the road 
+going south from Bucklebury. Built around 
+a stone quarry that was abandoned long ago, 
+the village is composed of ancient and sturdy 
+stone houses with thatched roofs. The folk 
+of Standelf carry on a good trade across the 
+Brandywine with the Hobbits of Rushey, forg-
+ing the bog iron harvested there into axes 
+and other tools. In return, they keep that 
+community well stocked with pork and wild 
+berries, both of which are found in abun-
+dance in the village.
+James Smith (Order #47812382)
+
+Buckland
+47
+A DINNER AT HUGO’S GRUFF
+Though not as hospitable as the tables in Bucklebury and 
+Brandy Hall, the folk of Newbury tell outlandish tales on 
+quiet nights, even for Bucklanders.
+The Lore­master can roll a Feat Die to see what yarn 
+they’re spinning on any particular night.
+NEWBURY TALES TABLE
+FEAT DIE 
+ROLL
+RESULT
+“Anyone foolish enough to drink the water from the Withywindle ages a hundred years in a day. Why 
+do you think they call it the ‘Old’ Forest?”
+1
+“All those birds and beasts you see in the woods? They used to be Hobbits. But you go too deep and 
+you get transformed — forever.”
+2
+“A bearded Hobbit lives in those woods and he’s taken a fairy wife. It’s true. I seen ‘em dancing 
+together beneath the trees at midsummer.”
+3
+“Watch the trees, they say. I say watch the thorns. You prick a finger on a thorn in the Old Forest, and 
+the oaks and elms and willows get a taste for your blood. Drain you dry they will, leaving your husk out 
+for the crows that lurk in the Barrow-­downs beyond.”
+4
+“Brandybucks didn’t come outta no Shire! They came from the east, I tell you. Walked right out the 
+Old Forest planning on taking the Shire for their own. Ain’t real Hobbits, but spirits that just look like 
+Shire folk.”
+5
+“Bees in that wood are as big as sparrows. Swarm on you and carry you away they will — never to be 
+seen again.”
+6
+“They say if you die under the eaves of the Old Forest, your body gets wrapped in vines and sunken 
+into the soil forever, until the land claims everything about you — even your memory, and no Hobbit 
+remembers you ever existed.”
+7
+“Only thing keeping the forest from reclaiming Buckland are secret runes written on the North Gate. 
+Put there by Gandalf the Grey they were, and invisible to the likes of you and me.”
+8
+“Yes, I tried to join the guards that mind the High Hay, but I wasn’t willing to go into the Old Forest 
+alone and make a pact with the dark spirits near the Bonfire Glade. It’s not right, I tell you.  
+Not right at all.”
+9
+“All a bunch of poppycock, I say. Ain’t nothing strange about that wood except for the mine at the cen-
+ter. That’s right, a mine! Dwarves moving through the Shire are slipping into the Old Forest where they 
+dig for gold. That’s where Baggins really got his ‘Dwarf gold.’”
+10
+“Ain’t the trees moving in that place, but a family of Trolls living on the banks of the Withywindle. Want 
+nothing to do with the likes of you and me. Just want to be left to their own peace.”
+“Of course the animals in the Old Forest can talk! Everything can! The birds, the beasts, the trees! Got 
+a sorcerous master they all do, and he’ll transform you into a furry critter just to bind you to his service 
+he will — all with a promise and a song.”
+James Smith (Order #47812382)
+
+THE SHIRE
+48
+the old forest
+It was not called the Old Forest without reason, for it was indeed ancient,  
+a survivor of vast forgotten woods; and in it there lived yet, ageing no quicker than the hills,  
+the fathers of the fathers of trees, remembering times when they were lords.
+Not part of the Shire proper, even by the standards of the 
+Bucklanders, the Old Forest warrants more than a bit of dis-
+cussion, in spite of what proper Shire-­Hobbits might claim. 
+Unwillingly bordered on its western side by the Hedge, it 
+runs clean over the Withywindle in the south before very 
+nearly touching the dreaded Barrow-­downs, farther from 
+the Shire than any sensible Hobbit would dare to walk. Its 
+northern end is visible to anyone crossing the Brandywine 
+and making their way east to Bree. To the few Hobbits that 
+dare to make such a journey, the road takes a northerly turn 
+and moves further away from the shadowy eaves of the Old 
+Forest as it goes.
+Little is said of the Old Forest by folks in the Shire, and 
+even less is believed. Many hold it to be extremely old, much 
+more than its name would suggest. Trees that were ancient 
+when Marcho and Blanco were young still grow there, and 
+many tales claim that they offer naught but malice to any 
+that dare to invade their domain. Particularly foolish tweens, 
+reckless even by the standards of a Brandybuck, challenge 
+each other to sneak beyond the High Hay and touch the 
+closest tree within its borders. Even this game is only played 
+on the brightest of summer days, and it is never a solitary 
+endeavour.
+All manner of queer tales find their origins in the Old 
+Forest. From enchanted fairy maidens that use scented flow-
+ers to entrap foolish travellers, to the fearsome Master of the 
+Forest capable of ordering the trees to rise from their roots 
+and devour trespassers. Even the river that runs through the 
+heart of the Old Forest, the Withywindle, is said to lull any 
+who drink from its water into a magical slumber from which 
+they will never awaken.
+In the end, no Hobbit of any sense thinks too deeply 
+about the truth of the Old Forest, let alone ventures within 
+it. Even so, legends persist that there are some among the 
+Shire-­folk who dare to make such journeys in search of some 
+secret wisdom, which they keep private from their fellows.
+James Smith (Order #47812382)
+
+The Old Forest
+49
+STRANGE ENCOUNTERS IN THE OLD FOREST
+Should the Player-­heroes choose to venture into the Old 
+Forest, the Lore­master can roll a Feat Die on the following 
+table to determine what the ill-­tempered trees and sav-
+age beasts have in store for these wayward wanderers.
+OLD FOREST ENCOUNTERS TABLE
+FEAT DIE 
+ROLL
+RESULT
+DESCRIPTION
+A Song in from 
+the Rushes
+The low and gentle voice of a lady singing is heard to the south, filled with hope 
+and beauty. It stirs the hearts of all who hear it before fading away. All Player-­
+heroes regain 1 Hope.
+1–2
+Clawing 
+and Falling 
+Branches
+The trees sway and rock as the Player-­heroes pass by, seeming to claw with hard 
+wooden talons at their skin, and heavy branches fall suddenly and hard upon them. 
+Attempting to pull free or dodge out of the way of these dangers requires an 
+ATHLETICS roll. Those who fail are struck by a fallen branch or find their arms and 
+legs cut by clutching limbs that refuse for a long time to release them, and lose 
+3 Endurance.
+3
+Dazzling Leaves
+The wanderers find themselves entranced by the dance of the leaves in the bright, 
+thin rays of the sun. This vision of enchantment lingers in their minds, requiring each 
+Player-­hero to make a WISDOM roll to drive away the haunting images that continue 
+to plague them during their time in the Old Forest.
+4
+Irritating Flies
+Swarms of stinging flies assault the Company, mercilessly biting any exposed flesh. 
+Swatting and dodging seems to do no good. It is long before the cloud moves on, 
+and each Player-­hero loses 1 Endurance as well as losing 1 Hope due to the misera-
+ble, lingering pain.
+5
+Mad Eyes 
+Upon You
+The trees! You swear they’re watching you! They haven’t eyes, but you know they’re 
+watching you as you pass, an unwelcome guest waiting to be expelled. Any minute 
+they could strike, and their predatory gaze is driving you mad! Unless a successful 
+WISDOM roll is made, each Player-­hero loses 2 points of Hope.
+6
+Tangling Roots
+Roots and vines seem to twist and writhe, binding the Player-­hero’s legs. Slowly 
+they tighten, until becoming quite painful. Unless a Player-­hero can succeed at an 
+ATHLETICS roll, they lose 2 Endurance and suffer a slowing limp (all ATHLETICS rolls 
+lose (−1) until they take a Prolonged Rest.
+7–8
+Twisting Paths
+The trees appear to have moved when the Player-­heroes weren’t looking, and the 
+path they were following seems to have closed off. Looking back, they see the road 
+behind them is not as they remember it.
+9
+Ivy Most 
+Unkind
+The Player-­heroes have walked through a patch of leafy ivy and lichen that has 
+caused their skin to break out in painful welts. They each lose 2 Endurance, but can 
+attempt a HEALING roll to avoid this.
+10
+Caught in a 
+Thorny Garden
+The Player-­heroes have stumbled into a great bramble of thorns, startling a family 
+of badgers. Several of these beasts chitter and seem rather cross at this intrusion. 
+Tearing themselves free of the thorns causes a Player-­hero to lose 3 Endurance, 
+but if the Player-­heroes make a successful COURTESY test and ask the badgers for 
+aid, they will lead the Player-­heroes from the thorns without injury.
+Hunted by a 
+Forest Predator
+A pack of wolves (one per Player-­hero; or the Burnt Beast, if it still exists, see Adven-
+tures, page 27) is hunting the Company while they are lost in the Old Forest.
+James Smith (Order #47812382)
+
+THE SHIRE
+50
+James Smith (Order #47812382)
+
+The Old Forest
+51
+the house of tom bombadil
+Just beyond the Old Forest to the east, where the Withywindle 
+runs down from its spring in the Barrow-downs, and known to 
+few save those who were brought to it by the Master himself, 
+is the warm and inviting House of Tom Bombadil. Found over 
+a hill and under that same hill, those who are guided there 
+and invited inside find comfort and lightened hearts beyond 
+any they could imagine in the Old Forest. The grass nearby is 
+shorn, and the forest is tended as if a garden or manicured 
+hedge, and an easy path leads to a house of stone with golden 
+light shining through the windows.
+Those who take refuge here do so only by the will of Bom-
+badil and at his invitation. Under his roof and at his table, 
+they will find their heart contented with peaceful slumber, 
+fine company, joyous song, and all the simple pleasures that 
+come with a humble heart. Lamps hang, casting a warm light 
+over a wooden table that is often laden with food, with a sin-
+gle empty chair set before it as if awaiting a woodland queen 
+to take her proper seat.
+Guests are welcomed with plates of berries and honey 
+and given warm mattresses to sleep upon. They will find sleep 
+comes easy, and none of the nightly noises will set fear into 
+their hearts.
+the withywindle
+This small dark river of brown water owes its name to the many 
+ancient willows that border its banks, arch over it, and some-
+times even block its course with fallen logs and thousands of 
+faded willow-leaves. It gently flows from the uplands of the 
+Barrow-­downs to the east, into the Brandywine to the west, 
+and crosses the entire width of the Old Forest. Mist clings to 
+its banks on autumn mornings, and no Hobbits of Buckland 
+or the Shire dares to set a boat into its waters, in spite of its 
+easy flow. Only the Hobbits of Breredon keep a small landing 
+from where they mostly cast rods for fishing.
+The folk of Haysend claim the Withywindle belongs 
+to no one, save the River-­Daughter, whom they say to be 
+as fair and beautiful as summer, and as elusive as a dream. 
+They say that the occasional water lily that is seen floating 
+along in its current is a sign of her presence, and should 
+be taken as an omen of good luck. Some even believe that 
+those who listen closely can hear her singing, though no 
+one has ever seen her when these songs of soft joy are heard 
+on spring winds.
+TOM BOMBADIL, THE MASTER
+Tom Bombadil is a truly unknowable being. His simple, 
+joyful existence is one spent in song, gathering tokens 
+for his beloved wife Goldberry, and playing mischie-
+vous games with the woodland creatures. He walks with 
+a merry step, singing songs that seem to be naught but 
+nonsense. In spite of his lightness of heart, or perhaps 
+because of it, no ill thing of the Old Forest can set itself 
+against him. Indeed, there is no evil that has touched 
+his heart, and his true nature is unknown, even to the 
+Wise. He stands taller than a Hobbit, yet less so than 
+a Man, and is clad in a blue jacket, great yellow boots, 
+and sports a full beard as brown as the fertile soil upon 
+which he dances.
+It would be foolish to dismiss his strange songs as 
+nonsense though, for Tom is as old as old, as wise as 
+wise, and for all his merriment, has knowledge beyond 
+measure. Whether it is the gladness in his heart that 
+prevents any evil from threatening him or it is the 
+nature of his spirit no one can say — Tom is the Master 
+of the Old Forest, and unconcerned with affairs beyond 
+his domain.
+Should Player-­heroes find themselves invited to stay 
+by Tom Bombadil in his house, they will find their hearts 
+lightened and their hope restored. They will be invited 
+to feast and sing and tell tales to Tom and his beloved 
+wife Goldberry in return for this hospitality.
+Anyone acting in a respectful manner and joining 
+Tom in this merry making can make a SONG roll. Those 
+who pass recover 1 Hope, +1 for each 
+ icon rolled. 
+In addition, if the characters brought with them any 
+beasts of burden or hounds, those creatures will be 
+blessed to remain keen of mind and stout of heart for 
+the rest of their days. Such a creature will understand the 
+verbal commands of their master. Finally, such a beast 
+blessed by Bombadil will always be able to find their 
+way back to Tom if they become lost in the Old Forest 
+or Barrow-­downs.
+James Smith (Order #47812382)
+
+THE SHIRE
+52
+OLD MAN WILLOW
+Deep in the Old Forest, somewhere along 
+the banks of the Withywindle, grows a great 
+and twisted willow tree, gnarled and hoary, 
+with its great branches hanging over the 
+dark water and its roots drinking deep. 
+Unlike the River-­Daughter, it has a fearful 
+reputation, and the Hobbits of Buckland 
+speak of it only in whispers and fearful 
+verses. Its grey and yellow leaves sway softly 
+in the breeze, though there is an aura of 
+ill-­will that seems to radiate from its trunk. 
+The few Bucklanders that have seen it say 
+this tree is as old as the earth itself, while the 
+Hobbits of Breredon believe it is a thirsty 
+earth-­bound spirit that has been impris-
+oned in the greatest willow of the Old For-
+est. Whatever the truth is, it is likely known 
+to no one.
+Old Man Willow, as he is named by the 
+Master, is a hateful thing that sets his ill 
+will towards any Hobbits or other interlop-
+ing invaders of the Old Forest. His sway-
+ing leaves put a spell on all those who see 
+them or hear their rustle, setting weariness 
+in their body until all they wish to do is 
+lean against his trunk and surrender to 
+the foul enchantment. Once asleep, under 
+those shading branches and with their back 
+against that gnarled bark, Old Man Willow 
+opens his roots. The slumbering traveller 
+falls in and is never seen again.
+GOLDBERRY, THE RIVER-­DAUGHTER
+Beautiful and calm, the elusive maiden some call Gold-
+berry possesses an Elvish kind of beauty. She is an 
+enchantment and a mystery to all whom she encounters. 
+Golden-­haired and clad in a dress of reeds and living 
+flowers, she springs lightly as the wind upon the banks 
+of the river. Singing with the natural beauty of a summer 
+rain, she shares songs that raise the hearts of all who are 
+blessed to hear her. She conceals herself well in the Old 
+Forest, and though some believe her to be a river-­spirit, 
+no one knows her true nature — only that she is the lady 
+of the Master, Tom Bombadil, and that he regularly dotes 
+upon her by plucking water lilies from the banks of the 
+Withywindle to present to her as token of his love.
+The blessed few who hear the song of Goldberry 
+the River-­Daughter find their fear driven back, and all 
+darkness seems far away. Hearts are lightened by the joy 
+of her presence and the fairness of her voice, and those 
+who hear her regain 1 point of Hope from the gift of 
+such a song and a smile.
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)
+
+James Smith (Order #47812382)


### PR DESCRIPTION
## Summary
- create `extract_ring_pdfs.py` to export plaintext from The One Ring PDFs
- store generated `.txt` files in `static/text/the-one-ring`

## Testing
- `pytest -q`
- `python extract_ring_pdfs.py`

------
https://chatgpt.com/codex/tasks/task_e_684f758661248329b232ef41d4df6aa5