### PR TITLE
Fix the-one-ring chat endpoint

### DIFF
--- a/static/the-one-ring/index.html
+++ b/static/the-one-ring/index.html
@@ -97,7 +97,7 @@
         input.value = "";
 
         try {
-          const response = await fetch("https://mydemerzel.onrender.com/chat", {
+          const response = await fetch("/chat", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ message: userMessage })


### PR DESCRIPTION
## Summary
- update the-one-ring page to use the local `/chat` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7d2e59ec8329b1525b93c090ab83