### PR TITLE
Increase response max tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,7 +185,7 @@ def chat():
             print("Embedding search failed:", e)
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo", messages=full_messages, max_tokens=100
+        model="gpt-3.5-turbo", messages=full_messages, max_tokens=2000
     )
     trimmed = response.choices[0].message.content.strip()
     messages.append({"role": "assistant", "content": trimmed, "timestamp": timestamp})


### PR DESCRIPTION
## Summary
- adjust OpenAI API call to allow responses up to 2000 tokens

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa8c8dd5c83299434468e3113bea1