### PR TITLE
Increase GPT-4o max_tokens to 4096

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,7 +206,7 @@ def chat():
             print("Embedding search failed:", e)
 
     response = client.chat.completions.create(
-        model="gpt-4o", messages=full_messages, max_tokens=2000
+        model="gpt-4o", messages=full_messages, max_tokens=4096
     )
     trimmed = response.choices[0].message.content.strip()
     messages.append({"role": "assistant", "content": trimmed, "timestamp": timestamp})


### PR DESCRIPTION
## Summary
- increase `client.chat.completions.create` token limit to 4096

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff63f1c108329a76fbb3799c8cc6f