### PR TITLE
Add basic auth to routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask_cors import CORS, cross_origin
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, Response
+from functools import wraps
 import datetime
 import os
 from dotenv import load_dotenv
@@ -16,22 +17,52 @@ app = Flask(__name__, static_folder="static")
 CORS(app, resources={r"/*": {"origins": "*"}})
 
 
+# Simple HTTP Basic Auth setup
+USERNAME = "Demerzel"
+PASSWORD = "Seraphine"
+
+
+def check_auth(username, password):
+    return username == USERNAME and password == PASSWORD
+
+
+def authenticate():
+    return Response(
+        "Authentication required", 401, {"WWW-Authenticate": 'Basic realm="Login Required"'}
+    )
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+
+    return decorated
+
+
 @app.route("/")
+@requires_auth
 def root():
     return app.send_static_file("index.html")
 
 
 @app.route("/the-one-ring")
+@requires_auth
 def the_one_ring():
     return app.send_static_file("the-one-ring/index.html")
 
 
 @app.route("/call-of-cthulhu")
+@requires_auth
 def call_of_cthulhu():
     return app.send_static_file("call-of-cthulhu/index.html")
 
 
 @app.route("/master-template")
+@requires_auth
 def master_template():
     return app.send_static_file("master-template/index.html")
 

--- a/test_full_app.py
+++ b/test_full_app.py
@@ -1,6 +1,12 @@
 import types
+import base64
 from unittest.mock import patch
 from app import app
+
+AUTH_HEADER = {
+    "Authorization": "Basic "
+    + base64.b64encode(b"Demerzel:Seraphine").decode("utf-8")
+}
 
 
 def fake_openai_response(content="Hello from OpenAI"):
@@ -11,7 +17,7 @@ def fake_openai_response(content="Hello from OpenAI"):
 
 def test_root_page():
     with app.test_client() as client:
-        resp = client.get("/")
+        resp = client.get("/", headers=AUTH_HEADER)
         assert resp.status_code == 200
         assert b"Demerzel" in resp.data
 
@@ -20,7 +26,7 @@ def test_static_pages():
     paths = ["/the-one-ring", "/call-of-cthulhu", "/master-template"]
     with app.test_client() as client:
         for path in paths:
-            resp = client.get(path)
+            resp = client.get(path, headers=AUTH_HEADER)
             assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- add HTTP Basic Auth helper functions in `app.py`
- secure static file routes with `@requires_auth`
- update tests to pass auth headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505a7a0f6483298819b36c81082ae3