### PR TITLE
Add auth header to chat test

### DIFF
--- a/test_full_app.py
+++ b/test_full_app.py
@@ -40,7 +40,7 @@ def test_chat_success():
         return_value=fake_openai_response("test reply"),
     ) as mock_create:
         with app.test_client() as client:
-            resp = client.post("/chat", json={"message": "hello"})
+            resp = client.post("/chat", json={"message": "hello"}, headers=AUTH_HEADER)
             assert resp.status_code == 200
             data = resp.get_json()
             assert data["response"] == "test reply"


### PR DESCRIPTION
## Summary
- include AUTH_HEADER in `test_chat_success` to reflect new auth requirement for `/chat`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505f608d308329b21a35c231b02747