### PR TITLE
Replace Basic Auth with Flask-Login

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,13 @@
 from flask_cors import CORS, cross_origin
-from flask import Flask, jsonify, request, Response
-from functools import wraps
+from flask import Flask, jsonify, request, render_template_string, redirect, url_for
+from flask_login import (
+    LoginManager,
+    login_user,
+    login_required,
+    logout_user,
+    UserMixin,
+    current_user,
+)
 import datetime
 import os
 from dotenv import load_dotenv
@@ -16,53 +23,71 @@ app = Flask(__name__, static_folder="static")
 # Explicitly allow cross-origin requests from any domain to fix frontend CORS errors
 CORS(app, resources={r"/*": {"origins": "*"}})
 
-
-# Simple HTTP Basic Auth setup
-USERNAME = "Demerzel"
-PASSWORD = "Seraphine"
-
-
-def check_auth(username, password):
-    return username == USERNAME and password == PASSWORD
+app.secret_key = "REPLACE_WITH_A_SECRET_KEY"
+login_manager = LoginManager()
+login_manager.init_app(app)
+login_manager.login_view = "login"
 
 
-def authenticate():
-    return Response(
-        "Authentication required", 401, {"WWW-Authenticate": 'Basic realm="Login Required"'}
+class User(UserMixin):
+    def __init__(self, id):
+        self.id = id
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User(user_id)
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username")
+        password = request.form.get("password")
+        if username == "Demerzel" and password == "Seraphine":
+            user = User(id="Demerzel")
+            login_user(user)
+            return redirect(url_for("root"))
+        return "Invalid credentials", 401
+
+    return render_template_string(
+        """
+        <form method="POST">
+            <input name="username" placeholder="Username"><br>
+            <input name="password" type="password" placeholder="Password"><br>
+            <button type="submit">Login</button>
+        </form>
+    """
     )
 
 
-def requires_auth(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        auth = request.authorization
-        if not auth or not check_auth(auth.username, auth.password):
-            return authenticate()
-        return f(*args, **kwargs)
-
-    return decorated
+@app.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for("login"))
 
 
 @app.route("/")
-@requires_auth
+@login_required
 def root():
     return app.send_static_file("index.html")
 
 
 @app.route("/the-one-ring")
-@requires_auth
+@login_required
 def the_one_ring():
     return app.send_static_file("the-one-ring/index.html")
 
 
 @app.route("/call-of-cthulhu")
-@requires_auth
+@login_required
 def call_of_cthulhu():
     return app.send_static_file("call-of-cthulhu/index.html")
 
 
 @app.route("/master-template")
-@requires_auth
+@login_required
 def master_template():
     return app.send_static_file("master-template/index.html")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 urllib3==2.4.0
 Werkzeug==3.1.3
+flask-login==0.6.3

--- a/test_full_app.py
+++ b/test_full_app.py
@@ -1,12 +1,6 @@
 import types
-import base64
 from unittest.mock import patch
 from app import app
-
-AUTH_HEADER = {
-    "Authorization": "Basic "
-    + base64.b64encode(b"Demerzel:Seraphine").decode("utf-8")
-}
 
 
 def fake_openai_response(content="Hello from OpenAI"):
@@ -15,9 +9,18 @@ def fake_openai_response(content="Hello from OpenAI"):
     )
 
 
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "Demerzel", "password": "Seraphine"},
+        follow_redirects=True,
+    )
+
+
 def test_root_page():
     with app.test_client() as client:
-        resp = client.get("/", headers=AUTH_HEADER)
+        login(client)
+        resp = client.get("/")
         assert resp.status_code == 200
         assert b"Demerzel" in resp.data
 
@@ -25,8 +28,9 @@ def test_root_page():
 def test_static_pages():
     paths = ["/the-one-ring", "/call-of-cthulhu", "/master-template"]
     with app.test_client() as client:
+        login(client)
         for path in paths:
-            resp = client.get(path, headers=AUTH_HEADER)
+            resp = client.get(path)
             assert resp.status_code == 200
 
 
@@ -40,7 +44,8 @@ def test_chat_success():
         return_value=fake_openai_response("test reply"),
     ) as mock_create:
         with app.test_client() as client:
-            resp = client.post("/chat", json={"message": "hello"}, headers=AUTH_HEADER)
+            login(client)
+            resp = client.post("/chat", json={"message": "hello"})
             assert resp.status_code == 200
             data = resp.get_json()
             assert data["response"] == "test reply"


### PR DESCRIPTION
## Summary
- swap custom Basic Auth for Flask-Login session handling
- add login and logout routes
- protect page routes with `@login_required`
- update tests to perform a session login
- add flask-login to requirements

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506293986483299cbd2759b07ac271