### PR TITLE
Fix campaign save return

### DIFF
--- a/scripts/chatbot_campaign_manager.py
+++ b/scripts/chatbot_campaign_manager.py
@@ -204,6 +204,30 @@ def process_user_request(user_request, session_state=None):
                 "session_state": session_state,
             }
 
+        # Reset onboarding state after successful save
+        session_state = {"onboarding": False, "answers": {}, "current_q": 0}
+
+        logging.debug(f"Scenario response payload: {scenario['campaign_markdown'][:200]}")
+
+        try:
+            return {
+                "response": (
+                    f"✅ Campaign created and saved to `dune_campaign.txt`!\n\n"
+                    f"Here’s a preview:\n\n"
+                    f"{scenario['campaign_markdown'][:1000]}...\n\n"
+                    f"(Full file is available in your repo.)"
+                ),
+                "takeover": False,
+                "session_state": session_state,
+            }
+        except Exception as e:
+            logging.error(f"❌ Exception during response build: {e}")
+            return {
+                "response": "❌ Internal server error while finalizing campaign.",
+                "takeover": False,
+                "session_state": session_state,
+            }
+
     else:
         # Not onboarding; normal chat processing
         logging.debug("Not onboarding; passing back control")


### PR DESCRIPTION
## Summary
- fix final return block in `chatbot_campaign_manager`
- log the campaign preview when onboarding finishes
- handle errors while finalizing campaign

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685881d76c9c83298239e1546cd6f341