### PR TITLE
Configure git identity for auto commits

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,9 @@
+import subprocess
+
+# ─── Ensure Git has an identity for auto-commit on Render ───
+subprocess.run(["git", "config", "--global", "user.email", "render-bot@yourdomain.com"], check=False)
+subprocess.run(["git", "config", "--global", "user.name", "Render Bot"], check=False)
+
 from flask_cors import CORS, cross_origin
 from flask import Flask, jsonify, request, session, render_template, redirect, url_for
 from flask_login import (


### PR DESCRIPTION
## Summary
- ensure git identity is set on startup so Render can auto commit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588dce32e0832995be6ef65c2618d6