### PR TITLE
Add Render git config snippet

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,25 @@
+import os
 import subprocess
 
-# ─── Ensure Git has an identity for auto-commit on Render ───
-subprocess.run(["git", "config", "--global", "user.email", "render-bot@yourdomain.com"], check=False)
-subprocess.run(["git", "config", "--global", "user.name", "Render Bot"], check=False)
+# — Ensure Git has a committer identity on Render
+subprocess.run(
+    ["git", "config", "--global", "user.email", "render-bot@yourdomain.com"],
+    check=False
+)
+subprocess.run(
+    ["git", "config", "--global", "user.name", "Render Bot"],
+    check=False
+)
+
+# — Rewrite the origin URL to include your GitHub deploy token
+token = os.environ.get("GITHUB_TOKEN")
+if token:
+    # Replace with your actual GitHub repo
+    repo = "github.com/Jronin201/mydemerzel-project.git"
+    subprocess.run([
+        "git", "remote", "set-url", "origin",
+        f"https://{token}@{repo}"
+    ], check=False)
 
 from flask_cors import CORS, cross_origin
 from flask import Flask, jsonify, request, session, render_template, redirect, url_for


### PR DESCRIPTION
## Summary
- ensure Git identity and remote URL are configured with GITHUB_TOKEN in `app.py`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685891d0b71c832997bd01c6913a7f9e